### PR TITLE
display inline collections in table widgets on report pages

### DIFF
--- a/intermine/web/main/src/org/intermine/web/struts/CollectionTableAction.java
+++ b/intermine/web/main/src/org/intermine/web/struts/CollectionTableAction.java
@@ -1,0 +1,88 @@
+package org.intermine.web.struts;
+
+/*
+ * Copyright (C) 2002-2013 FlyMine
+ *
+ * This code may be freely distributed and modified under the
+ * terms of the GNU Lesser General Public Licence.  This should
+ * be distributed with the code.  See the LICENSE file for more
+ * information or http://www.gnu.org/copyleft/lesser.html.
+ *
+ */
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.apache.struts.action.Action;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.intermine.api.InterMineAPI;
+import org.intermine.metadata.ClassDescriptor;
+import org.intermine.metadata.ReferenceDescriptor;
+import org.intermine.model.InterMineObject;
+import org.intermine.objectstore.ObjectStore;
+import org.intermine.web.logic.results.PagedTable;
+import org.intermine.web.logic.session.SessionMethods;
+
+/**
+ * Action that creates a table of collection elements for display in a table widget.
+ *
+ */
+public class CollectionTableAction extends Action
+{
+    /**
+     * Create PagedTable for this collection, register it with an identifier 
+     *
+     * @param mapping
+     *            The ActionMapping used to select this instance
+     * @param form
+     *            The optional ActionForm bean for this request (if any)
+     * @param request
+     *            The HTTP request we are processing
+     * @param response
+     *            The HTTP response we are creating
+     * @return an ActionForward object defining where control goes next
+     * @exception Exception
+     *                if an error occurs
+     */
+    public ActionForward execute(ActionMapping mapping, ActionForm form,
+            HttpServletRequest request, HttpServletResponse response)
+        throws Exception {
+        HttpSession session = request.getSession();
+        final InterMineAPI im = SessionMethods.getInterMineAPI(session);
+        ObjectStore os = im.getObjectStore();
+
+        Integer id = new Integer(request.getParameter("id"));
+        String field = request.getParameter("field");
+        String trail = request.getParameter("trail");
+        String path = request.getParameter("pathString");
+
+        InterMineObject o = os.getObjectById(id);
+
+        ReferenceDescriptor refDesc = null;
+        for (ClassDescriptor cld : os.getModel().getClassDescriptorsForClass(o.getClass())) {
+            refDesc = (ReferenceDescriptor) cld.getFieldDescriptorByName(field);
+            if (refDesc != null) {
+                break;
+            }
+        }
+        String referencedClassName = refDesc.getReferencedClassDescriptor().getUnqualifiedName();
+
+        PagedTable pagedTable = SessionMethods.doQueryGetPagedTable(request, o, field,
+                                                                    referencedClassName);
+
+        // add results table to trail
+        if (trail != null) {
+            trail += "|results." + pagedTable.getTableid();
+        } else {
+            trail = "|results." + pagedTable.getTableid();
+        }
+        request.setAttribute("noSelect","true");
+        request.setAttribute("table",pagedTable.getTableid());
+        request.setAttribute("trail",trail);
+
+        return mapping.findForward("table");
+    }
+}

--- a/intermine/webapp/main/resources/webapp/WEB-INF/struts-config.xml
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/struts-config.xml
@@ -167,6 +167,9 @@
     <action path="/collectionDetails" type="org.intermine.web.struts.CollectionDetailsAction">
       <forward name="results" redirect="true" path="/results.do"/>
     </action>
+    <action path="/collectionToTable" type="org.intermine.web.struts.CollectionTableAction">
+     <forward name="table" path="/table.jsp"/>
+     </action>
     <action path="/queryBuilderChange" type="org.intermine.web.struts.QueryBuilderChange" parameter="method">
       <forward name="query" redirect="true" path="/query.do"/>
       <forward name="browserLines" path="/queryBuilderBrowserLines.jsp"/>

--- a/intermine/webapp/main/resources/webapp/reportRefsCols.jsp
+++ b/intermine/webapp/main/resources/webapp/reportRefsCols.jsp
@@ -34,10 +34,11 @@
         value="${imf:formatFieldStr(pathString, INTERMINE_API, WEBCONFIG)}"/>
 
     <c:set var="placementAndField" value="${aspectPlacement}_${fieldName}" />
-        <%-- ############# --%>
+    <c:set var="divName" value="${fn:replace(aspectPlacement, ':', '_')}${fieldName}_table" /> 
+
         <div id="${fn:replace(aspectPlacement, ":", "_")}${fieldName}_table" class="collection-table">
         <a name="${fieldName}" class="anchor"></a>
-        <h3>
+        <h3 id="${divName}_h3">
           <c:if test="${SHOW_TAGS}">
             <div class="right">
               <c:set var="descriptor" value="${collection.descriptor}" />
@@ -52,27 +53,58 @@
         </h3>
         <div class="clear"></div>
         <%-- ############# --%>
-    <c:choose>
-      <c:when test="${collection.size > 0}">
+        <c:choose>
+         <c:when test="${collection.size > 0}">
           <div id="coll_${fn:replace(aspectPlacement, ":", "_")}${fieldName}">
-          <div id="coll_${fn:replace(aspectPlacement, ":", "_")}${fieldName}_inner" style="overflow-x:auto;">
-
-            <c:set var="inlineResultsTable" value="${collection.table}"/>
-
-            <tiles:insert page="/reportCollectionTable.jsp">
+          <div id="coll_${fn:replace(aspectPlacement, ":", "_")}${fieldName}_inner" style="overflow-x:hidden;">
+          <c:set var="innerDivName" value="coll_${fn:replace(aspectPlacement, ':', '_')}${fieldName}" /> 
+          <c:set var="inlineResultsTable" value="${collection.table}"/>
+          <c:set var="useTableWidget" value="${WEB_PROPERTIES['inline.collections.in.tables']=='true'}" />
+          <c:set var="useLocalStorage" value="${WEB_PROPERTIES['use.localstorage']=='true'}" />
+          <c:choose>
+            <c:when test="${useTableWidget}">
+              <tiles:insert page="/collectionToTable.do?field=${fieldName}&id=${object.id}&trail=${param.trail}&pathString=${object.classDescriptor.unqualifiedName}.${fieldName}"> 
+              </tiles:insert>
+            </c:when>
+            <c:otherwise>
+             <tiles:insert page="/reportCollectionTable.jsp"> 
               <tiles:put name="inlineResultsTable" beanName="inlineResultsTable" />
               <tiles:put name="object" beanName="object" />
               <tiles:put name="fieldName" value="${fieldName}" />
-            </tiles:insert>
-            <script type="text/javascript">trimTable('#coll_${fn:replace(aspectPlacement, ":", "_")}${fieldName}_inner');</script>
+             </tiles:insert>
+            </c:otherwise> 
+          </c:choose>
+          <script type="text/javascript">
+            trimTable('#coll_${fn:replace(aspectPlacement, ":", "_")}${fieldName}_inner');
+            $(function(){
+                if(${useLocalStorage} && typeof(Storage)!=="undefined"){
+                 if(localStorage.${innerDivName}==undefined || localStorage.${innerDivName} == "hide"){
+                   $('#${innerDivName}').hide();
+                   localStorage.${innerDivName}="hide";
+                 }
+              }
+              $('#${divName}_h3').click(function(e){
+               $('#${innerDivName}').slideToggle('fast');
+               if(${useLocalStorage} && typeof(Storage)!=="undefined"){
+                 if(localStorage.${innerDivName}=="hide"){
+                     localStorage.${innerDivName}="show";
+                 }else{
+                     localStorage.${innerDivName}="hide";
+                 }
+               }
+               });
+            });
+          </script>
           </div>
-
-          <div class="show-in-table" style="display:none;">
-            <html:link action="/collectionDetails?id=${object.id}&amp;field=${fieldName}&amp;trail=${param.trail}">
-              Show all in a table »
-            </html:link>
-          </div>
-
+          <c:choose>
+            <c:when test="${!useTableWidget}">
+              <div class="show-in-table" style="display:none;">
+              <html:link action="/collectionDetails?id=${object.id}&amp;field=${fieldName}&amp;trail=${param.trail}">
+                Show all in a table
+              </html:link>
+              </div> 
+            </c:when>
+          </c:choose>
           </div>
           <div class="clear"></div>
         <%-- ############# --%>

--- a/intermine/webapp/main/resources/webapp/reportTemplate.jsp
+++ b/intermine/webapp/main/resources/webapp/reportTemplate.jsp
@@ -33,7 +33,7 @@
 <c:set var="templateName" value="${templateQuery.name}"/>
 <c:set var="uid" value="${fn:replace(placement, ' ', '_')}_${templateName}"/>
 <c:set var="placementAndField" value="${placement}_${templateName}"/>
-
+<c:set var="useLocalStorage" value="${WEB_PROPERTIES['use.localstorage']=='true'}"/>
 
 <c:choose>
     <c:when test="${reportObject != null}">
@@ -77,10 +77,34 @@
                 var view = new intermine.query.results.CompactView($SERVICE, query, LIST_EVENTS, {pageSize: 10});
                 view.$el.appendTo('#${tableContainerId}');
                 view.render();
+                if(typeof(Storage) !=="undefined"){
+                  localStorage.${elemId} = "show";
+                }
+                var options = {
+                    type: 'table',
+                    service: $SERVICE,
+                    query: query,
+                    events: LIST_EVENTS,
+                    properties: {pageSize: 10}
+                };
+                jQuery('#${tableContainerId}').imWidget(options);
                 $(this).unbind('click').click(function(e) {
                     $('#${tableContainerId}').slideToggle('fast');
+
+                    if(${useLocalStorage} && typeof(Storage) !=="undefined"){
+                      if(localStorage.${elemId} == "show"){
+                        localStorage.${elemId} = "hide";
+                      }else{
+                        localStorage.${elemId} = "show";
+                      }
+                    }	
                 });
             });
+            if(${useLocalStorage} && typeof(Storage)!=="undefined"){
+              if(localStorage.${elemId} == "show"){
+                 $('#${elemId} h3').click();
+              }
+            }
         });
     }).call(window, jQuery);
   </script>


### PR DESCRIPTION
This branch is based on intermine/master.

There are two properties to configure the new functionality.
**inline.collections.in.tables = true**
This will display any inline collections in table widgets.
Unless use.localstorage is true they will appear expanded but can be collapsed.

**use.localstorage = true**
Both inline collections and templates will initially appear collapsed.
Their state will be tracked using local storage if available.

Using two properties seems like it is a bit excessive but my objective was to allow the new code to be added with no changes to the way the pages appeared. Since there are two slightly independent features, and the existing behavior is for collections to be displayed and templates to be collapsed, I split them into two properties.
