### PR TITLE
Use correct path to do attribute check. Refs #777

### DIFF
--- a/intermine/web/main/src/org/intermine/web/logic/pathqueryresult/PathQueryResultHelper.java
+++ b/intermine/web/main/src/org/intermine/web/logic/pathqueryresult/PathQueryResultHelper.java
@@ -103,7 +103,10 @@ public final class PathQueryResultHelper
             if (fieldConfig.getShowInResults()) {
                 try {
                     Path path = new Path(model, prefix + "." + relPath);
-                    if (path.isOnlyAttribute()) {
+                    // use type (e.g. Protein) not prefix (e.g. Gene.proteins) to do
+                    // attribute check
+                    Path checkIsOnlyAttribute = new Path(model, type + "." + relPath);
+                    if (checkIsOnlyAttribute.isOnlyAttribute()) {
                         view.add(path.getNoConstraintsString());
                     }
                 } catch (PathException e) {


### PR DESCRIPTION
The problem was the "convert" link on the list analysis page would run a query and display all fields for that class instead of just the ones that were configured.

The method of interest, `getDefaultViewForClass()`, is used when we have a query and a type but no view list. We want to get the view list set in the config file. This method is used a great deal, e.g. on the list analysis page. 

The problem is the code was using the full path, e.g. `Gene.proteins.accession` instead of `Protein.accession` and (for some reason) the code discards non-attributes. Normally, e.g. for list analysis page, this isn't a problem. But since these are conversion templates, it was discarding all fields configured therefore using all fields -- which is the default behaviour when there is no config.

Refs #777 
