### PR TITLE
Use current tables release.

### DIFF
--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -87,7 +87,7 @@ head.js.all.M = CDN/js/intermine/imjs/2.10.x/im.min.js
 head.js.all.Y = shim.js
 head.js.all.Z = intermine.js
 
-head.css.results.RESULT_TABLES = CDN/js/intermine/im-tables/1.7.x/imtables.css
+head.css.results.RESULT_TABLES = CDN/js/intermine/im-tables/1.9.x/imtables.css
 
 head.css.results.JQUI = jquery-ui-1.10.3.custom.css
 


### PR DESCRIPTION
This updates the tables to the current release, which fixes a number of bugs.

In particular this fixes #839 and #838 

Note that this will require mine administrators to choose between glyphicons (the default) or fontawesome (more flexible, but not supported in older IEs) in the future.
