### PR TITLE
Only support Chromosome location for range constraints.

### DIFF
--- a/intermine/api/main/src/org/intermine/api/query/MainHelper.java
+++ b/intermine/api/main/src/org/intermine/api/query/MainHelper.java
@@ -1565,9 +1565,9 @@ public final class MainHelper
         private static void init() {
             rangeHelpers = new HashMap<Class<?>, RangeHelper>();
             // Default basic helpers.
-            rangeHelpers.put(int.class, new IntHelper());
-            rangeHelpers.put(Integer.class, new IntHelper());
-            rangeHelpers.put(String.class, new StringHelper());
+//            rangeHelpers.put(int.class, new IntHelper());
+//            rangeHelpers.put(Integer.class, new IntHelper());
+//            rangeHelpers.put(String.class, new StringHelper());
             loadHelpers(PropertiesUtil.getProperties());
         }
 


### PR DESCRIPTION
We only want to support chromosome location queries for ranges. Otherwise we are adding complexity for little/no benefit. In the case of strings, CONTAINS behaves quite differently, it's changed to a LIKE *keyword* constraint. Refs #797