### PR TITLE
Fixes #902 (report page fails to render)

### DIFF
--- a/intermine/web/main/src/org/intermine/web/logic/WebUtil.java
+++ b/intermine/web/main/src/org/intermine/web/logic/WebUtil.java
@@ -709,7 +709,7 @@ public abstract class WebUtil
                 return true;
             }
         } catch (PathException e) {
-            return false;
+            // Ignore. Dynamic objects can be screwy.
         }
         return false;
     }

--- a/intermine/web/main/src/org/intermine/web/logic/WebUtil.java
+++ b/intermine/web/main/src/org/intermine/web/logic/WebUtil.java
@@ -691,4 +691,26 @@ public abstract class WebUtil
 
         return StringUtils.join(returners, " > ");
     }
+
+    /**
+     * Check whether the runtime type of an object supports a particular path.
+     * E.g.: An Employee supports the "department.name" path.
+     * @param obj The object we want to inspect.
+     * @param path The headless path we want to use.
+     * @param api A reference to the API object.
+     * @return true if the path is valid for this object.
+     */
+    public static boolean hasValidPath(Object obj, String path, InterMineAPI api) {
+        try {
+            Model m = api.getModel();
+            Collection<ClassDescriptor> clds = m.getClassDescriptorsForClass(obj.getClass());
+            for (ClassDescriptor cd: clds) {
+                new Path(api.getModel(), cd.getUnqualifiedName() + "." + path);
+                return true;
+            }
+        } catch (PathException e) {
+            return false;
+        }
+        return false;
+    }
 }

--- a/intermine/webapp/main/resources/webapp/WEB-INF/functions.tld
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/functions.tld
@@ -87,7 +87,13 @@
       <function-class>org.intermine.web.logic.WebUtil</function-class>
       <function-signature>boolean containsKey(java.util.Map, java.lang.Object)</function-signature>
   </function>
-  
 
+  <function>
+    <name>hasValidPath</name>
+    <function-class>org.intermine.web.logic.WebUtil</function-class>
+    <function-signature>
+      boolean hasValidPath(java.lang.Object, java.lang.String, org.intermine.api.InterMineAPI)
+    </function-signature>
+  </function>
 
 </taglib>

--- a/intermine/webapp/main/resources/webapp/otherMinesLink.jsp
+++ b/intermine/webapp/main/resources/webapp/otherMinesLink.jsp
@@ -2,9 +2,10 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
+<%@ taglib uri="/WEB-INF/functions.tld" prefix="imf" %>
 
 <!-- This section is rendered with Ajax to improve responsiveness -->
-<c:if test="${!empty mines}">
+<c:if test="${!empty mines && imf:hasValidPath(object, 'organism.shortName', INTERMINE_API)}">
 <script type="text/javascript" charset="utf-8" src="js/other-mines-links.js"></script>
 <h3 class="goog"><fmt:message key="othermines.title"/></h3>
 <div id="friendlyMines">


### PR DESCRIPTION
This adds a WebUtil function to check if an object supports a particular
path, and uses that to make sure the otherMinesLink jsp does not raise
an exception.

Fixes #902