### PR TITLE
Only log a missing bioseg warning if we can't use built-in range types. ...

### DIFF
--- a/intermine/objectstore/main/src/org/intermine/objectstore/intermine/ObjectStoreInterMineImpl.java
+++ b/intermine/objectstore/main/src/org/intermine/objectstore/intermine/ObjectStoreInterMineImpl.java
@@ -439,7 +439,11 @@ public class ObjectStoreInterMineImpl extends ObjectStoreAbstractImpl implements
                     }
                 }
 
+                // if we're above Postgres version 9.2 we can use the built-in range types
+                boolean useRangeTypes = database.isVersionAtLeast("9.2");
+
                 // Check if there is a bioseg index in the database for faster range queries
+                // - if we can use range types we don't really need to check this but useful to know
                 boolean hasBioSeg = false;
                 Connection c = null;
                 try {
@@ -449,7 +453,10 @@ public class ObjectStoreInterMineImpl extends ObjectStoreAbstractImpl implements
                     hasBioSeg = true;
                 } catch (SQLException e) {
                     // We don't have bioseg
-                    LOG.warn("Database " + osAlias + " doesn't have bioseg", e);
+                    if (!useRangeTypes) {
+                        // only log a warning if we can't use range types, otherwise no problem
+                        LOG.warn("Database " + osAlias + " doesn't have bioseg", e);
+                    }
                 } finally {
                     if (c != null) {
                         try {
@@ -459,9 +466,6 @@ public class ObjectStoreInterMineImpl extends ObjectStoreAbstractImpl implements
                         }
                     }
                 }
-
-                // if we're above Postgres version 9.2 we can use the built-in range types
-                boolean useRangeTypes = database.isVersionAtLeast("9.2");
 
                 DatabaseSchema schema = new DatabaseSchema(osModel, truncatedClasses, noNotXml,
                         missingTables, formatVersion, hasBioSeg, useRangeTypes);


### PR DESCRIPTION
...Fixes #869.