### PR TITLE
add option to filter terms created by OBO converter by a prefix. Refs #9...

### DIFF
--- a/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
@@ -168,7 +168,7 @@ public class OboConverter extends DataConverter
             return null;
         }
         String termId = (term.getId() == null ? term.getName() : term.getId());
-        if (prefix != null && !termId.startsWith(prefix)) {
+        if (prefix != null && !termId.toLowerCase().startsWith(prefix.toLowerCase())) {
             final String msg = "Not processing OBO term: " + term.getId() + " " + term.getName()
                     + " because it does not start with prefix " + prefix;
             LOG.info(msg);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
@@ -52,6 +52,7 @@ public class OboConverter extends DataConverter
     protected Map<OboTermSynonym, Item> synToItem = new HashMap<OboTermSynonym, Item>();
     protected Item ontology;
     private boolean createRelations = true;
+    protected String prefix = null;
 
     /**
      * Constructor for this class.
@@ -85,6 +86,19 @@ public class OboConverter extends DataConverter
         } else {
             this.createRelations = false;
         }
+    }
+
+    /**
+     * The prefix of ontology terms to be processed. Everything before the colon, e.g GO or SO
+     * or ZFA. Whilst processing, if a term is encountered without this prefix it will be
+     * discarded.
+     *
+     * See https://github.com/intermine/intermine/issues/901 for details.
+     *
+     * @param prefix prefix of the identifier for the terms of interest, eg. GO or SO or ZFA
+     */
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
     }
 
     /**
@@ -154,6 +168,12 @@ public class OboConverter extends DataConverter
             return null;
         }
         String termId = (term.getId() == null ? term.getName() : term.getId());
+        if (prefix != null && !termId.startsWith(prefix)) {
+            final String msg = "Not processing OBO term: " + term.getId() + " " + term.getName()
+                    + " because it does not start with prefix " + prefix;
+            LOG.info(msg);
+            return null;
+        }
         Item item = nameToTerm.get(termId);
         if (item == null) {
             item = createItem(termClass);

--- a/bio/core/test/src/org/intermine/bio/dataconversion/OboConverterTest.java
+++ b/bio/core/test/src/org/intermine/bio/dataconversion/OboConverterTest.java
@@ -36,6 +36,7 @@ public class OboConverterTest extends ItemsTestCase {
     public void test1() throws Exception {
         OboConverter converter = new OboConverter(itemWriter, model, "", "SO", "http://www.flymine.org",
                                                   "OntologyTerm");
+        converter.setPrefix("SO");
         OboTerm a = new OboTerm("SO:42", "parent");
         OboTerm b = new OboTerm("SO:43", "child");
         OboTerm c = new OboTerm("SO:44", "partof");
@@ -55,6 +56,32 @@ public class OboConverterTest extends ItemsTestCase {
         converter.storeItems();
         //writeItemsFile(itemWriter.getItems(), "obo-converter-tgt.xml");
         assertEquals(readItemSet("OboConverterTest.xml"), itemWriter.getItems());
+    }
+
+    public void testPrefix() throws Exception {
+        OboConverter converter = new OboConverter(itemWriter, model, "", "SO", "http://www.flymine.org",
+                                                  "OntologyTerm");
+        converter.setPrefix("MONKEY");
+        OboTerm a = new OboTerm("SO:42", "parent");
+        OboTerm b = new OboTerm("SO:43", "child");
+        OboTerm c = new OboTerm("SO:44", "partof");
+        OboTerm d = new OboTerm("SO:45", "obsolete");
+        d.setObsolete(true);
+        c.addSynonym(new OboTermSynonym("syn2", "exact_synonym"));
+        b.addSynonym(new OboTermSynonym("syn1", "narrow_synonym"));
+        b.addSynonym(new OboTermSynonym("syn2", "exact_synonym"));
+        d.addSynonym(new OboTermSynonym("syn2", "exact_synonym"));
+        d.addSynonym(new OboTermSynonym("syn3", "narrow_synonym"));
+        OboRelation r1 = new OboRelation("SO:43","SO:42",new OboTypeDefinition("is_a", "is_a", true));
+        OboRelation r2 = new OboRelation("SO:44","SO:43",new OboTypeDefinition("part_of", "part_of", true));
+        OboRelation r3 = new OboRelation("SO:43","SO:45",new OboTypeDefinition("is_a", "is_a", true));
+
+        converter.setOboTerms(Arrays.asList(new OboTerm[] {a, b, c, d}));
+        converter.setOboRelations(Arrays.asList(new OboRelation[] {r1,r2,r3} ));
+        converter.storeItems();
+
+        // prefix should make sure no terms gets stored, only the ontology is
+        assertEquals(itemWriter.getItems().size(), 1);
     }
 
 }


### PR DESCRIPTION
...01

To test:

You can use the fly anatomy file because it has SO and GO terms as well as FBBT.

1. Run without a prefix. Should load SO and GO terms as fly anatomy terms
2. Run with valid prefix, e.g. FBBT. 
3. Run with invalid prefix, e.g. MONKEY, no terms should be created. Only the ontology.