### PR TITLE
fix LOOKUPs with wildcards. Refs #978

### DIFF
--- a/intermine/api/main/src/org/intermine/api/bag/BagQuery.java
+++ b/intermine/api/main/src/org/intermine/api/bag/BagQuery.java
@@ -206,6 +206,10 @@ public class BagQuery
                         nodes.put((QueryEvaluable) ((BagConstraint) c).getQueryNode(), replacement);
                         cs.addConstraint(replacement);
                     }
+                } else if (c instanceof MultipleInBagConstraint) {
+                    for (QueryEvaluable qe : ((MultipleInBagConstraint) c).getEvaluables()) {
+                        nodes.put(qe, cs);
+                    }
                 } else if (c instanceof ConstraintSet) {
                     traverseConstraint(c, nodes);
                 }


### PR DESCRIPTION
Fix LOOKUPs with wildcards. I don't really know how this worked before.

Sergio -- can you test this works with:

* templates and queries
* LOOKUPs and with regular constraints
* wildcards and regular strings
* list upload works as expected