### PR TITLE
Allow the allowed origin to be preconfigured.

### DIFF
--- a/intermine/web/main/src/org/intermine/webservice/server/WebService.java
+++ b/intermine/web/main/src/org/intermine/webservice/server/WebService.java
@@ -400,7 +400,9 @@ public abstract class WebService
             }
         }
 
-        String origin = request.getHeader("Origin");
+        String origin = StringUtils.defaultIfBlank(
+                    webProperties.getProperty("ws.response.origin"),
+                    request.getHeader("Origin"));
         if (StringUtils.isNotBlank(origin)) {
             response.setHeader("Access-Control-Allow-Origin", origin);
         }


### PR DESCRIPTION
This is a small pull request that allows the value for the Allowed-Origin header to be set to a constant.

In your `.intermine/MINE.properties` file, set the following property:

```properties
ws.response.origin = *
```

Then the allowed-origins=* header will be set for all WS requests. You can also use this to restrict access by origin.