### PR TITLE
Fix orthologue links by breaking them.

### DIFF
--- a/bio/webapp/resources/webapp/model/js/friendly-mines.js
+++ b/bio/webapp/resources/webapp/model/js/friendly-mines.js
@@ -101,12 +101,6 @@ var FriendlyMines = (function ($, AjaxServices) {
             value: request.origin
           }
         ];
-        if (group.domain !== request.domain) {
-          data.push({
-            name: FriendlyMines.DOMAIN_PARAMETER,
-            value: group.domain
-          });
-        }
         im.log('Making portal request with:', data);
 
         makePostRequest(mine.url + '/portal.do', data);


### PR DESCRIPTION
Because of the way this bit of code is designed, we aren't correctly setting the orthologue parameter. This parameter is needed when we send genes that need to be converted. However it's currently being set always which is causing problems.

All mines now have orthologues loaded so we can get away with removing this for now. maybe.

