### PR TITLE
Should fix problem where table cell popup previews are too big.

### DIFF
--- a/intermine/webapp/main/resources/webapp/bagDetails.jsp
+++ b/intermine/webapp/main/resources/webapp/bagDetails.jsp
@@ -148,7 +148,7 @@
 
 <TD valign="top" class="tableleftcol">
 
-<div class="results collection-table nowrap nomargin">
+<div class="results collection-table nomargin">
 
 <style type="text/css">
     .bag-detail-table { max-width: 1000px; }


### PR DESCRIPTION
This should hopefully fix the "embiggening" issue where im-tables popup previews are expanding off the page. This issue seems to have returned.

I can't test this because my test model doesn't have fields that are too long to run off the page.

Julie, if you get a chance, can you try deploying this to HumanMine? It's a simple one line CSS change in bagDetails.jsp. If it breaks everything then reverting should be easy.