### PR TITLE
stop build if search fails. Refs #992

### DIFF
--- a/intermine/api/main/src/org/intermine/api/lucene/InterMineObjectFetcher.java
+++ b/intermine/api/main/src/org/intermine/api/lucene/InterMineObjectFetcher.java
@@ -186,10 +186,11 @@ public class InterMineObjectFetcher extends Thread
             }
         } catch (Exception e) {
             LOG.warn(null, e);
+            throw new RuntimeException("Index creation failed: ", e);
+        } finally {
+            //notify main thread that we're done
+            indexingQueue.finish();
         }
-
-        //notify main thread that we're done
-        indexingQueue.finish();
     }
 
     private Document handleObject(


### PR DESCRIPTION
Fails loudly if the keyword search errors. We don't want to fail silently. If something has gone wrong we need to stop the build.

To test: have bad keyword search config.