### PR TITLE
make interaction region a bioentity. This is required because it uses…

### DIFF
--- a/bio/sources/psi/main/src/org/intermine/bio/dataconversion/PsiConverter.java
+++ b/bio/sources/psi/main/src/org/intermine/bio/dataconversion/PsiConverter.java
@@ -757,7 +757,6 @@ public class PsiConverter extends BioFileConverter
                     location.setAttribute("end", ih.end);
                     location.setReference("locatedOn", geneRefId);
                     location.setReference("feature", refId);
-                    region.setReference("location", location);
                     store(location);
                 }
                 store(region);

--- a/bio/sources/psi/psi_additions.xml
+++ b/bio/sources/psi/psi_additions.xml
@@ -38,13 +38,13 @@
         <collection name="interactions" referenced-type="Interaction" reverse-reference="gene1"/>
     </class>
 
-    <class name="InteractionRegion" is-interface="true">
+    <class name="InteractionRegion" extends="BioEntity"  is-interface="true">
       <attribute name="startStatus" type="java.lang.String"/>
       <attribute name="endStatus" type="java.lang.String"/>
       <reference name="gene" referenced-type="Gene" />
       <reference name="ontologyTerm" referenced-type="OntologyTerm"/>
-      <reference name="location" referenced-type="Location"/>
       <reference name="interaction" referenced-type="InteractionDetail" reverse-reference="interactingRegions"/>
+      <collection name="locations" referenced-type="Location" reverse-reference="feature"/>
     </class>
 </classes>
 


### PR DESCRIPTION
… the location object, which references a bioentity. Refs #962