### PR TITLE
Update Database.java

### DIFF
--- a/intermine/objectstore/main/src/org/intermine/sql/Database.java
+++ b/intermine/objectstore/main/src/org/intermine/sql/Database.java
@@ -300,8 +300,8 @@ public class Database implements Shutdownable
         StringBuffer urlBuffer = new StringBuffer();
         urlBuffer.append("jdbc:" + platform.toLowerCase() + "://");
         urlBuffer.append((String) settings.get("datasource.serverName"));
-        if (settings.get("datasource.portNumber") != null) {
-            urlBuffer.append(":" + (String) settings.get("datasource.portNumber"));
+        if (settings.get("datasource.port") != null) {
+            urlBuffer.append(":" + (String) settings.get("datasource.port"));
         }
         urlBuffer.append("/" + (String) settings.get("datasource.databaseName"));
         String url = urlBuffer.toString();


### PR DESCRIPTION
The database server port was incorrectly referenced as "datasource.portName" rather than "datasource.port", thus breaking the ability to connect to a PostgreSQL database on a non-standard port. This fix has been tested to work.