### PR TITLE
Always add slash to id resolver path

### DIFF
--- a/bio/core/main/src/org/intermine/bio/dataconversion/EnsemblIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/EnsemblIdResolverFactory.java
@@ -80,7 +80,7 @@ public class EnsemblIdResolverFactory extends IdResolverFactory
                     createFromFile(f);
                     resolver.writeToFile(new File(idResolverCachedFileName));
                 } else {
-                    LOG.warn("Resolver file not exists: " + resolverFileName);
+                    LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
             }
         } catch (Exception e) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/EnsemblIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/EnsemblIdResolverFactory.java
@@ -82,6 +82,8 @@ public class EnsemblIdResolverFactory extends IdResolverFactory
                 } else {
                     LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
+            } else {
+                LOG.info("Using previously cached id resolver file: " + idResolverCachedFileName);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/EnsemblIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/EnsemblIdResolverFactory.java
@@ -74,7 +74,7 @@ public class EnsemblIdResolverFactory extends IdResolverFactory
                 }
 
                 LOG.info("Creating id resolver from data file and caching it.");
-                String resolverFileName = resolverFileRoot.trim() + resolverFileSymbo;
+                String resolverFileName = resolverFileRoot.trim() + "/" + resolverFileSymbo;
                 File f = new File(resolverFileName);
                 if (f.exists()) {
                     createFromFile(f);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/EntrezGeneIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/EntrezGeneIdResolverFactory.java
@@ -179,7 +179,7 @@ public class EntrezGeneIdResolverFactory extends IdResolverFactory
                 }
 
                 LOG.info("Creating id resolver from data file and caching it.");
-                String resolverFileName = resolverFileRoot.trim() + resolverFileSymbo;
+                String resolverFileName = resolverFileRoot.trim() + "/" + resolverFileSymbo;
                 File f = new File(resolverFileName);
                 if (f.exists()) {
                     createFromFile(f, taxonIds);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/EntrezGeneIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/EntrezGeneIdResolverFactory.java
@@ -185,7 +185,7 @@ public class EntrezGeneIdResolverFactory extends IdResolverFactory
                     createFromFile(f, taxonIds);
                     resolver.writeToFile(new File(idResolverCachedFileName));
                 } else {
-                    LOG.warn("Resolver file not exists: " + resolverFileName);
+                    LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
             }
         } catch (Exception e) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/EntrezGeneIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/EntrezGeneIdResolverFactory.java
@@ -187,6 +187,8 @@ public class EntrezGeneIdResolverFactory extends IdResolverFactory
                 } else {
                     LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
+            } else {
+                LOG.info("Using previously cached id resolver file: " + idResolverCachedFileName);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/HgncIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/HgncIdResolverFactory.java
@@ -75,7 +75,7 @@ public class HgncIdResolverFactory extends IdResolverFactory
                 }
 
                 LOG.info("Creating id resolver from data file and caching it.");
-                String resolverFileName = resolverFileRoot.trim() + resolverFileSymbo;
+                String resolverFileName = resolverFileRoot.trim() + "/" + resolverFileSymbo;
                 File f = new File(resolverFileName);
                 if (f.exists()) {
                     createFromFile(f);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/HgncIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/HgncIdResolverFactory.java
@@ -83,6 +83,8 @@ public class HgncIdResolverFactory extends IdResolverFactory
                 } else {
                     LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
+            } else {
+                LOG.info("Using previously cached id resolver file: " + idResolverCachedFileName);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/HgncIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/HgncIdResolverFactory.java
@@ -81,7 +81,7 @@ public class HgncIdResolverFactory extends IdResolverFactory
                     createFromFile(f);
                     resolver.writeToFile(new File(idResolverCachedFileName));
                 } else {
-                    LOG.warn("Resolver file not exists: " + resolverFileName);
+                    LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
             }
         } catch (Exception e) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/HumanIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/HumanIdResolverFactory.java
@@ -74,7 +74,7 @@ public class HumanIdResolverFactory extends IdResolverFactory
                 }
 
                 LOG.info("Creating id resolver from data file and caching it.");
-                String resolverFileName = resolverFileRoot.trim() + resolverFileSymbo;
+                String resolverFileName = resolverFileRoot.trim() + "/" + resolverFileSymbo;
                 File f = new File(resolverFileName);
                 if (f.exists()) {
                     createFromFile(f);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/HumanIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/HumanIdResolverFactory.java
@@ -82,6 +82,8 @@ public class HumanIdResolverFactory extends IdResolverFactory
                 } else {
                     LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
+            } else {
+                LOG.info("Using previously cached id resolver file: " + idResolverCachedFileName);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/HumanIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/HumanIdResolverFactory.java
@@ -80,7 +80,7 @@ public class HumanIdResolverFactory extends IdResolverFactory
                     createFromFile(f);
                     resolver.writeToFile(new File(idResolverCachedFileName));
                 } else {
-                    LOG.warn("Resolver file not exists: " + resolverFileName);
+                    LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
             }
         } catch (Exception e) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/MgiIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/MgiIdentifiersResolverFactory.java
@@ -92,7 +92,7 @@ public class MgiIdentifiersResolverFactory extends IdResolverFactory
                     createFromFile(f);
                     resolver.writeToFile(new File(idResolverCachedFileName));
                 } else {
-                    LOG.warn("Resolver file not exists: " + resolverFileName);
+                    LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
             }
         } catch (Exception e) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/MgiIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/MgiIdentifiersResolverFactory.java
@@ -94,6 +94,8 @@ public class MgiIdentifiersResolverFactory extends IdResolverFactory
                 } else {
                     LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
+            } else {
+                LOG.info("Using previously cached id resolver file: " + idResolverCachedFileName);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/MgiIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/MgiIdentifiersResolverFactory.java
@@ -86,7 +86,7 @@ public class MgiIdentifiersResolverFactory extends IdResolverFactory
                 }
 
                 LOG.info("Creating id resolver from data file and caching it.");
-                String resolverFileName = resolverFileRoot.trim() + resolverFileSymbo;
+                String resolverFileName = resolverFileRoot.trim() + "/" + resolverFileSymbo;
                 File f = new File(resolverFileName);
                 if (f.exists()) {
                     createFromFile(f);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/RgdIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/RgdIdentifiersResolverFactory.java
@@ -84,7 +84,7 @@ public class RgdIdentifiersResolverFactory extends IdResolverFactory
                 }
 
                 LOG.info("Creating id resolver from data file and caching it.");
-                String resolverFileName = resolverFileRoot.trim() + resolverFileSymbo;
+                String resolverFileName = resolverFileRoot.trim() + "/" + resolverFileSymbo;
                 File f = new File(resolverFileName);
                 if (f.exists()) {
                     createFromFile(f);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/RgdIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/RgdIdentifiersResolverFactory.java
@@ -90,7 +90,7 @@ public class RgdIdentifiersResolverFactory extends IdResolverFactory
                     createFromFile(f);
                     resolver.writeToFile(new File(idResolverCachedFileName));
                 } else {
-                    LOG.warn("Resolver file not exists: " + resolverFileName);
+                    LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
             }
         } catch (Exception e) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/RgdIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/RgdIdentifiersResolverFactory.java
@@ -92,6 +92,8 @@ public class RgdIdentifiersResolverFactory extends IdResolverFactory
                 } else {
                     LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
+            } else {
+                LOG.info("Using previously cached id resolver file: " + idResolverCachedFileName);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/WormBaseIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/WormBaseIdResolverFactory.java
@@ -113,7 +113,7 @@ public class WormBaseIdResolverFactory extends IdResolverFactory
                     if (wb2NcbiDataFile.exists()) {
                         createFromWb2NcbiFile(wb2NcbiDataFile);
                     } else {
-                        LOG.warn("Resolver file not exists: " + wb2NcbiFileName);
+                        LOG.warn("Resolver file does not exist: " + wb2NcbiFileName);
                     }
                     // END OF HACK
 

--- a/bio/core/main/src/org/intermine/bio/dataconversion/WormBaseIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/WormBaseIdResolverFactory.java
@@ -119,9 +119,10 @@ public class WormBaseIdResolverFactory extends IdResolverFactory
 
                     resolver.writeToFile(new File(idResolverCachedFileName));
                 } else {
-                    LOG.warn("Resolver file not exists: " + wormIdFileName);
+                    LOG.warn("Resolver file does not exist: " + wormIdFileName);
                 }
-
+            } else {
+                LOG.info("Using previously cached id resolver file: " + idResolverCachedFileName);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/WormBaseIdResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/WormBaseIdResolverFactory.java
@@ -99,7 +99,7 @@ public class WormBaseIdResolverFactory extends IdResolverFactory
                 }
 
                 LOG.info("To process WormId file");
-                String wormIdFileName =  resolverFileRoot.trim() + resolverFileSymboWormId;
+                String wormIdFileName = resolverFileRoot.trim() + "/" + resolverFileSymboWormId;
                 File wormIdDataFile = new File(wormIdFileName);
 
                 if (wormIdDataFile.exists()) {
@@ -107,7 +107,7 @@ public class WormBaseIdResolverFactory extends IdResolverFactory
 
                     // HACK - Additionally, load WB2NCBI to have ncbi ids
                     LOG.info("To process WB2NCBI file");
-                    String wb2NcbiFileName = resolverFileRoot.trim() + resolverFileSymboWb2Ncbi;
+                    String wb2NcbiFileName = resolverFileRoot.trim() + "/" + resolverFileSymboWb2Ncbi;
                     File wb2NcbiDataFile = new File(wb2NcbiFileName);
 
                     if (wb2NcbiDataFile.exists()) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/ZfinIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/ZfinIdentifiersResolverFactory.java
@@ -97,6 +97,8 @@ public class ZfinIdentifiersResolverFactory extends IdResolverFactory
                 } else {
                     LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
+            } else {
+                LOG.info("Using previously cached id resolver file: " + idResolverCachedFileName);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/bio/core/main/src/org/intermine/bio/dataconversion/ZfinIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/ZfinIdentifiersResolverFactory.java
@@ -95,7 +95,7 @@ public class ZfinIdentifiersResolverFactory extends IdResolverFactory
                     createFromFile(f);
                     resolver.writeToFile(new File(idResolverCachedFileName));
                 } else {
-                    LOG.warn("Resolver file not exists: " + resolverFileName);
+                    LOG.warn("Resolver file does not exist: " + resolverFileName);
                 }
             }
         } catch (Exception e) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/ZfinIdentifiersResolverFactory.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/ZfinIdentifiersResolverFactory.java
@@ -89,7 +89,7 @@ public class ZfinIdentifiersResolverFactory extends IdResolverFactory
                 }
 
                 LOG.info("Creating id resolver from data file and caching it.");
-                String resolverFileName = resolverFileRoot.trim() + resolverFileSymbo;
+                String resolverFileName = resolverFileRoot.trim() + "/" + resolverFileSymbo;
                 File f = new File(resolverFileName);
                 if (f.exists()) {
                     createFromFile(f);


### PR DESCRIPTION
This is to alleviate an issue where the user may not do this (e.g. they just put 

```
resolver.file.rootpath=/micklem/data/idresolver
```

in their mine.properties but then id resolution fails because the code was simply appending the specific id resolver file (e.g. /micklem/data/idresolverentrez instead of /micklem/data/idresolver/entrez).  The user may not notice this since not finding the file just prints a warning to the log and does not halt the build.

I would have loved to have a badly configured path throw an exception to halt the build.  However, it struck me that a user may only have an ID resolver for some sources.  It may be correct for other sources to carry on if they cannot find a resolver because the file does not exist.  Whilst I see in the code there is a mechanism to ignore errors, the structure of the code means that it's not straightforward to stop 'not found file' errors being uncaught RuntimeExceptions anyway.

It looks like it will be difficult to do much about this unless things are changed so that individual bio sources have to explicitly say whether they want to use the ID resolver, in which case we can halt the build if it isn't found.  Personally, I think that would be better but it might be a big change.

Also, there's an awful lot of copy and paste between resolver classes which made these minor changes more difficult than they needed to be.  At some point, I think this should be refactored so that there's a single code path to reduce code complexity and the scope for bugs.