### PR TITLE
Rewrite make(BioEntity, SequenceType) to actually use the SequenceTyp…

### DIFF
--- a/bio/webapp/src/org/intermine/bio/web/biojava/BioSequenceFactory.java
+++ b/bio/webapp/src/org/intermine/bio/web/biojava/BioSequenceFactory.java
@@ -83,18 +83,24 @@ public abstract class BioSequenceFactory
             return new BioSequence(ProteinTools.createProtein(residues), protein);
         }
     }
-
     /**
-     * Create a new BioSequence from a BioEntity
+     * Create a new BioSequence from a BioEntity, given its SequenceType
      * @param bioEnt the bio entity
      * @param type the SequenceType
-     * @return a new BioSequence object or null if the Protein doesn't have a Sequence
-     * @throws IllegalSymbolException if any of the residues of the Protein can't be
-     * turned into amino acid symbols.
+     * @return a new BioSequence object or null if the BioEntity doesn't have a Sequence
+     * @throws IllegalSymbolException if any of the residues of the BioEntity can't be
+     * turned into symbols of the given SequenceType.
+	 * @author Sam Hokin
+	 *
+	 * NOTE: this has been rewritten by Sam Hokin, NCGR. It didn't formerly use the type parameter,
+	 * and simply polled the input BioEntity as to whether it was SequenceFeature or Protein, and
+	 * assumed DNA if SequenceFeature. The purpose of this version of make should be to force DNA
+	 * or Protein residues based on the type parameter, regardless of the type of BioEntity. 
+	 * I added RNA support as well.
      */
-    public static BioSequence make(BioEntity bioEnt, SequenceType type)
-        throws IllegalSymbolException {
-        if (bioEnt instanceof Protein) {
+    public static BioSequence make(BioEntity bioEnt, SequenceType type) throws IllegalSymbolException {
+		if (bioEnt instanceof Protein) {
+			// it really is a protein, which is not a SequenceFeature
             Protein protein = (Protein) bioEnt;
             if (protein.getSequence() == null || protein.getSequence().getResidues() == null) {
                 return null;
@@ -102,7 +108,17 @@ public abstract class BioSequenceFactory
                 String residues = protein.getSequence().getResidues().toString();
                 return new BioSequence(ProteinTools.createProtein(residues), protein);
             }
-        } else if (bioEnt instanceof SequenceFeature) {
+		} else if (type.equals(SequenceType.PROTEIN)) {
+			// it's an amino acid SequenceFeature, like a polypeptide from chado
+            SequenceFeature feature = (SequenceFeature) bioEnt;
+            if (feature.getSequence() == null || feature.getSequence().getResidues() == null) {
+                return null;
+            } else {
+                String residues = feature.getSequence().getResidues().toString();
+                return new BioSequence(ProteinTools.createProtein(residues), feature);
+            }
+        } else if (type.equals(SequenceType.DNA)) {
+			// it's a DNA sequence
             SequenceFeature feature = (SequenceFeature) bioEnt;
             if (feature.getSequence() == null || feature.getSequence().getResidues() == null) {
                 return null;
@@ -110,8 +126,18 @@ public abstract class BioSequenceFactory
                 String residues = feature.getSequence().getResidues().toString();
                 return new BioSequence(DNATools.createDNA(residues), feature);
             }
+		} else if (type.equals(SequenceType.RNA)) {
+			// we want an RNA sequence
+            SequenceFeature feature = (SequenceFeature) bioEnt;
+            if (feature.getSequence() == null || feature.getSequence().getResidues() == null) {
+                return null;
+            } else {
+                String residues = feature.getSequence().getResidues().toString();
+                return new BioSequence(RNATools.createRNA(residues), feature);
+            }
         } else {
-            throw new RuntimeException("Sequence type not defined.");
+            throw new RuntimeException("Sequence type not defined. Choices are PROTEIN, DNA, RNA.");
         }
     }
+    
 }


### PR DESCRIPTION
This method seems to have been mis-written originally. It did not use the SequenceType type parameter at all. It simply checked if the BioEntity is a Protein, in which case it returned an amino acid sequence, else it assumed the BioEntity was a DNA sequence. However, we have Polypeptides imported from chado as SequenceFeatures with amino acid residues. So I have rewritten this method to do what I think it is meant to do: use the input SequenceType to determine the type of sequence. (Ideally, SequenceFeature and Protein would have a standard field specifying the SequenceType and the three variations of make() would not be needed. There are sequence features like polypeptides in our case that are associated with a DNA locus but have PROTEIN or RNA residues.) I've also added support for SequenceType.RNA, which doesn't appear to have had any stock support so far.