### PR TITLE
point to bugfixed pathways displayer version 0.0.2. See #1126

### DIFF
--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -138,8 +138,8 @@ head.js.component-400.C = CDN/js/intermine/pomme.js/0.2.6/app.min.js
 head.css.component-400.all  = CDN/js/intermine/apps-c/component-400/0.5.0/css/component-400.bundle.min.css
 
 # Pathways Displayer on a Report Page.
-head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-displayer/0.0.1/app.js
-head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.1/pathways-displayer.css
+head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/app.js
+head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/pathways-displayer.css
 
 # Cytoscape Gene Interaction Displayer on Report Page
 head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.0/gene-interaction-displayer.js


### PR DESCRIPTION
Version 0.0.2 of the pathways displayer is live in the dev cdn, but before going to production we'll want to push to the prod CDN.