### PR TITLE
Fix Protein cytoscape viewer and expose useful js variables on report page

### DIFF
--- a/bio/webapp/resources/webapp/model/cytoscapeNetworkDisplayer.jsp
+++ b/bio/webapp/resources/webapp/model/cytoscapeNetworkDisplayer.jsp
@@ -52,7 +52,8 @@
             "value" : "${cytoscapeInteractionObjectId}",
             "path": "id",
             "op": "="
-          }
+          },
+          nodeType : imSummaryFields.type
         }).then(function(hasValues) {
           if (!hasValues) {
             element.parentElement.style.display = "none";

--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -138,8 +138,8 @@ head.js.component-400.C = CDN/js/intermine/pomme.js/0.2.6/app.min.js
 head.css.component-400.all  = CDN/js/intermine/apps-c/component-400/0.5.0/css/component-400.bundle.min.css
 
 # Pathways Displayer on a Report Page.
-head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-displayer/0.0.1/app.js
-head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.1/pathways-displayer.css
+head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/app.js
+head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/pathways-displayer.css
 
 # Cytoscape Gene Interaction Displayer on Report Page
 head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.0/gene-interaction-displayer.js

--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -142,8 +142,8 @@ head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-
 head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/pathways-displayer.css
 
 # Cytoscape Gene Interaction Displayer on Report Page
-head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.1/gene-interaction-displayer.js
-head.css.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.1/gene-interaction-displayer.css
+head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.2/gene-interaction-displayer.js
+head.css.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.2/gene-interaction-displayer.css
 
 
 

--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -142,8 +142,8 @@ head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-
 head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/pathways-displayer.css
 
 # Cytoscape Gene Interaction Displayer on Report Page
-head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.0/gene-interaction-displayer.js
-head.css.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.0/gene-interaction-displayer.css
+head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.1/gene-interaction-displayer.js
+head.css.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.1/gene-interaction-displayer.css
 
 
 

--- a/intermine/webapp/main/resources/webapp/report.jsp
+++ b/intermine/webapp/main/resources/webapp/report.jsp
@@ -15,6 +15,13 @@
   <%-- apply white background as report page loads slowly and body bg will show through --%>
   var pageBackgroundColor = jQuery('body').css('background-color');
   jQuery('body').css('background-color', '#FFF');
+
+  <%--  Expose useful properties to the js. The properties themselves are
+        set in the foreach later down the page --%>
+  var imSummaryFields = {
+    type : "${object.type}"
+  };
+
 </script>
 
 <c:choose>
@@ -69,6 +76,9 @@
       <c:set var="tableCount" value="0" scope="page" />
 
       <c:forEach var="field" items="${object.objectSummaryFields}">
+        <%-- Expose useful props to the js --%>
+        <script> imSummaryFields["${field.name}"] = "${field.value}";</script>
+
           <c:if test="${tableCount %2 == 0}">
             <c:choose>
               <c:when test="${tableCount == 0}">


### PR DESCRIPTION
Protein/Gene types needed to be exposed to tweak the query for the interaction viewer. 

Exposing the summaryfields variables and the type of object being shown will hopefully mean fewer java/jsp-side updates for front end scripts. They're available as a js global under `window.imSummaryFields`

Note that before putting this change live on the prod server, we will need the CDN dev branch to be merged into master to ensure that version 1.0.1 of the interaction displayer is available from the intermine CDN. 
