### PR TITLE
Pathways displayer

### DIFF
--- a/bio/webapp/resources/webapp/model/minePathwaysDisplayer.jsp
+++ b/bio/webapp/resources/webapp/model/minePathwaysDisplayer.jsp
@@ -40,7 +40,7 @@
   <c:set var="section" value="pathways-displayer"/>
 
   <c:forEach var="res" items="${imf:getHeadResources(section, PROFILE.preferences)}">
-    
+
       paths["${res.type}"]["${res.key}".split(".").pop()] = "${res.url}";
   </c:forEach>
 
@@ -92,8 +92,8 @@
 
         require('PathwaysDisplayer')(
       {
-             
-              friendlyMines: friendlyMines,                        
+
+              friendlyMines: friendlyMines,
               gene: "${gene.primaryIdentifier}",
               target: "#pathwaysappcontainer",
               themeColor: "${localMine.bgcolor}"
@@ -107,8 +107,9 @@
     imload();
 
   } catch (error) {
+    console.error(error);
     $('#pathwaysappcontainer').html(
-      $('<div/>', {'text': 'This app requires jQuery 2.x.x', 'style': 'padding-left: 14px; font-weight: bold'})
+      $('<div/>', {'text': 'Error loading pathways.', 'style': 'padding-left: 14px; font-weight: bold'})
     );
 
     $('#mine-pathway-displayer').addClass("warning");
@@ -121,7 +122,7 @@
 
 </script>
 
-    
+
 
 
 

--- a/flymine/webapp/resources/webapp/WEB-INF/webconfig-model.xml
+++ b/flymine/webapp/resources/webapp/WEB-INF/webconfig-model.xml
@@ -706,13 +706,13 @@
                      replacesFields="publications"
                      placement="Genes"
                      types="BioEntity"/>
-<!--
+
     <reportdisplayer javaClass="org.intermine.bio.web.displayer.MinePathwaysDisplayer"
                      jspName="model/minePathwaysDisplayer.jsp"
                      replacesFields="pathways"
                      placement="summary"
                      types="Gene"/>
--->
+
 
     <reportdisplayer javaClass="org.intermine.bio.web.displayer.DiseaseDisplayer"
                      jspName="model/diseaseDisplayer.jsp"

--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -60,7 +60,7 @@ begin.thirdBox.linkTitle = Tell me more!
 
 #### HEAD - configuration for the head element of pages, mainly scripts and style-sheets ###
 
-head.cdn.location = http://cdn-dev.intermine.org
+head.cdn.location = http://cdn.intermine.org
 
 head.css.all.A = inlineTagEditor.css
 head.css.all.B = resultstables.css

--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -60,7 +60,7 @@ begin.thirdBox.linkTitle = Tell me more!
 
 #### HEAD - configuration for the head element of pages, mainly scripts and style-sheets ###
 
-head.cdn.location = http://cdn.intermine.org
+head.cdn.location = http://cdn-dev.intermine.org
 
 head.css.all.A = inlineTagEditor.css
 head.css.all.B = resultstables.css
@@ -140,6 +140,10 @@ head.css.component-400.all  = CDN/js/intermine/apps-c/component-400/0.5.0/css/co
 # Pathways Displayer on a Report Page.
 head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/app.js
 head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/pathways-displayer.css
+head.js.pathways-displayer.Q = CDN/js/q/0.9.7/q.min.js
+head.js.pathways-displayer.jQuery = CDN/js/jquery/2.0.3/jquery.min.js
+head.js.pathways-displayer._ = CDN/js/underscore.js/1.4.4/underscore-min.js
+head.js.pathways-displayer.Backbone = CDN/js/backbone.js/1.1.0/backbone-min.js
 
 # Cytoscape Gene Interaction Displayer on Report Page
 head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.0/gene-interaction-displayer.js

--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -138,8 +138,8 @@ head.js.component-400.C = CDN/js/intermine/pomme.js/0.2.6/app.min.js
 head.css.component-400.all  = CDN/js/intermine/apps-c/component-400/0.5.0/css/component-400.bundle.min.css
 
 # Pathways Displayer on a Report Page.
-head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-displayer/0.0.1/app.js
-head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.1/pathways-displayer.css
+head.js.pathways-displayer.PathwaysDisplayer = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/app.js
+head.css.pathways-displayer.pathwaysDisplayerCSS = CDN/js/intermine/apps-c/pathways-displayer/0.0.2/pathways-displayer.css
 
 # Cytoscape Gene Interaction Displayer on Report Page
 head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.0/gene-interaction-displayer.js


### PR DESCRIPTION
Version 0.0.2 of the pathways displayer is live in the dev cdn, but before going to production we'll want to push to the prod CDN.