### PR TITLE
avoid NullPointerException when used with DirectDataLoader

### DIFF
--- a/intermine/integrate/main/src/org/intermine/dataloader/BatchingFetcher.java
+++ b/intermine/integrate/main/src/org/intermine/dataloader/BatchingFetcher.java
@@ -177,7 +177,7 @@ public class BatchingFetcher extends HintingFetcher
             if (fpo instanceof InterMineObject) {
                 InterMineObject imo = (InterMineObject) fpo;
 
-                if (idMap.get(imo.getId()) == null) {
+                if (imo.get() == null || idMap.get(imo.getId()) == null) {
                     objects.add(imo);
                     for (String fieldName : TypeUtil.getFieldInfos(imo.getClass()).keySet()) {
                         Object fieldValue;


### PR DESCRIPTION
I was getting a NullPointerException when used with the DirectDataLoader since the id had not been assigned to imo yet. The lack of an id should trigger the same behavior as not having the id in idMap.
