### PR TITLE
Stop logging a warning for each class in the model that does not have…

### DIFF
--- a/intermine/api/main/src/org/intermine/api/config/ClassKeyHelper.java
+++ b/intermine/api/main/src/org/intermine/api/config/ClassKeyHelper.java
@@ -80,12 +80,12 @@ public final class ClassKeyHelper
                                     + " for class " + clsName);
                         }
                     }
-                } else {
-                    LOG.warn("No key defined for " + clsName);
                 }
+
                 CLASS_KEYS.put(model, theseKeys);
             }
         }
+
         return CLASS_KEYS.get(model);
     }
 


### PR DESCRIPTION
… an entry in <mine>/class_keys.properties

This does not seem helpful as there are some classes that will not have a meaningful key (e.g. OntologyAnnotation).
Putting out warnings that the user cannot/should not correct just makes them ignore more legitimate warnings.