### PR TITLE
If ProxyReference.getObject() fails then attach triggering exception …

### DIFF
--- a/intermine/objectstore/main/src/org/intermine/objectstore/proxy/ProxyReference.java
+++ b/intermine/objectstore/main/src/org/intermine/objectstore/proxy/ProxyReference.java
@@ -64,7 +64,7 @@ public class ProxyReference implements InterMineObject, Lazy
         } catch (ObjectStoreException e) {
             throw new RuntimeException("ObjectStoreException while materialising proxy with ID "
                     + id + " for class " + clazz.getName() + " from ObjectStore " + os + ": "
-                    + e.getMessage());
+                    + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
…to ObjectStoreException

This helped me work out that my failure was due to running out of disk space - the simple exception message "Could not get connection to database" is opaque