### PR TITLE
Allow protein2ipr source to still work if no protein2ipr.organisms pr…

### DIFF
--- a/bio/sources/protein2ipr/main/src/org/intermine/bio/dataconversion/Protein2iprConverter.java
+++ b/bio/sources/protein2ipr/main/src/org/intermine/bio/dataconversion/Protein2iprConverter.java
@@ -222,7 +222,9 @@ public class Protein2iprConverter extends BioFileConverter
         ConstraintSet cs = new ConstraintSet(ConstraintOp.AND);
 
         // organism in our list
-        cs.addConstraint(new BagConstraint(qfOrganismTaxonId, ConstraintOp.IN, taxonIds));
+        if (taxonIds.size() > 0) {
+            cs.addConstraint(new BagConstraint(qfOrganismTaxonId, ConstraintOp.IN, taxonIds));
+        }
 
         // protein.organism = organism
         QueryObjectReference qor = new QueryObjectReference(qcProtein, "organism");

--- a/bio/sources/protein2ipr/test/src/org/intermine/bio/dataconversion/Protein2iprConverterTest.java
+++ b/bio/sources/protein2ipr/test/src/org/intermine/bio/dataconversion/Protein2iprConverterTest.java
@@ -112,4 +112,17 @@ public class Protein2iprConverterTest extends ItemsTestCase
 
         assertEquals(expected, itemWriter.getItems());
     }
+
+    public void testProcessNoOrganismSet() throws Exception {
+
+        Reader reader = new InputStreamReader(getClass().getClassLoader()
+                                            .getResourceAsStream(currentFile));
+        converter.setCurrentFile(new File(currentFile));
+        converter.process(reader);
+        converter.close();
+
+        Set<org.intermine.xml.full.Item> expected = readItemSet("Protein2iprConverterTest_tgt.xml");
+
+        assertEquals(expected, itemWriter.getItems());
+    }
 }


### PR DESCRIPTION
…operty is set

Using this constraint is an optimization but awkward for mines with lots of potentially changing taxons (e.g. synbiomine)