### PR TITLE
Added NetHTTPS type

### DIFF
--- a/intermine/perl/Webservice-InterMine/lib/Webservice/InterMine/Types.pm
+++ b/intermine/perl/Webservice-InterMine/lib/Webservice/InterMine/Types.pm
@@ -75,7 +75,7 @@ use MooseX::Types -declare => [
 
         Join JoinStyle JoinList
 
-        Uri HTTPCode NetHTTP
+        Uri HTTPCode NetHTTP NetHTTPS
 
         Service
         ServiceVersion
@@ -235,6 +235,7 @@ subtype PathDescriptionList, as ArrayRef [PathDescription];
 
 class_type Uri, { class => 'URI' };
 class_type NetHTTP, { class => 'Net::HTTP', };
+class_type NetHTTPS, { class => 'Net::HTTPS', };
 subtype HTTPCode, as Str, where { /^\d{3}$/ };
 
 coerce Uri, from Str, via {


### PR DESCRIPTION
Hi,

I added the NetHTTPS type after Joe had some issues using HTTPS for the web service.

I am not very familiar with this code base, so please do review these changes carefully.  I ran a single test to double check that my changes didn't break anything obvious.

prove -I lib -I../InterMine-Model/lib/ t/06_service/02_result_iterator.t
t/06_service/02_result_iterator.t .. ok
All tests successful.
Files=1, Tests=4,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.39 cusr  0.01 csys =  0.42 CPU)
Result: PASS

Cheers,
Josh