### PR TITLE
Fix sed bsd

### DIFF
--- a/biotestmine/setup.sh
+++ b/biotestmine/setup.sh
@@ -87,16 +87,16 @@ if test ! -f $IMDIR/$PROP_FILE; then
     echo "#---> $PROP_FILE not found. Providing default properties file..."
     cd $IMDIR
     cp $DIR/../bio/tutorial/malariamine.properties $PROP_FILE
-    sed -i "s/PSQL_USER/$PSQL_USER/g" $PROP_FILE
-    sed -i "s/PSQL_PWD/$PSQL_PWD/g" $PROP_FILE
-    sed -i "s/TOMCAT_USER/$TOMCAT_USER/g" $PROP_FILE
-    sed -i "s/TOMCAT_PWD/$TOMCAT_PWD/g" $PROP_FILE
-    sed -i "s/items-malariamine/$ITEMS_DB/g" $PROP_FILE
-    sed -i "s/userprofile-malariamine/$USERPROFILE_DB/g" $PROP_FILE
-    sed -i "s/databaseName=malariamine/databaseName=$PROD_DB/g" $PROP_FILE
-    sed -i "s/malariamine/$MINENAME/gi" $PROP_FILE
-    sed -i "s/localhost/$SERVER/g" $PROP_FILE
-    sed -i "s/8080/$PORT/g" $PROP_FILE
+    sed -i '' "s/PSQL_USER/$PSQL_USER/g" $PROP_FILE
+    sed -i '' "s/PSQL_PWD/$PSQL_PWD/g" $PROP_FILE
+    sed -i '' "s/TOMCAT_USER/$TOMCAT_USER/g" $PROP_FILE
+    sed -i '' "s/TOMCAT_PWD/$TOMCAT_PWD/g" $PROP_FILE
+    sed -i '' "s/items-malariamine/$ITEMS_DB/g" $PROP_FILE
+    sed -i '' "s/userprofile-malariamine/$USERPROFILE_DB/g" $PROP_FILE
+    sed -i '' "s/databaseName=malariamine/databaseName=$PROD_DB/g" $PROP_FILE
+    sed -i '' "s/malariamine/$MINENAME/gi" $PROP_FILE
+    sed -i '' "s/localhost/$SERVER/g" $PROP_FILE
+    sed -i '' "s/8080/$PORT/g" $PROP_FILE
     echo "#--- Created $PROP_FILE"
 fi
 
@@ -132,8 +132,8 @@ if test ! -f project.xml; then
 fi
 
 echo '#---> Personalising project.xml'
-sed -i "s!DATA_DIR!$DATA_DIR!g" project.xml
-sed -i "s/malariamine/$MINENAME/g" project.xml
+sed -i '' "s!DATA_DIR!$DATA_DIR!g" project.xml
+sed -i '' "s/malariamine/$MINENAME/g" project.xml
 
 if egrep -q ProteinDomain.shortName $PRIORITIES; then
     echo '#--- Integration key exists.'


### PR DESCRIPTION
The default sed on OSX doesn't like using -i with no arguments. Replacing this with -i '' allows biotestmine to be built


The error you get otherwise is

```
#---> Checking databases...
#--- biotestmine-userprofile exists.
#--- biotestmine exists.
#--- biotestmine-items exists.
#--- Sample data already exists.
#---> Personalising project.xml
sed: 1: "project.xml": extra characters at the end of p command
```