### PR TITLE
Fix BSD sed vol 2 for biotestmine

### DIFF
--- a/biotestmine/setup.sh
+++ b/biotestmine/setup.sh
@@ -87,16 +87,16 @@ if test ! -f $IMDIR/$PROP_FILE; then
     echo "#---> $PROP_FILE not found. Providing default properties file..."
     cd $IMDIR
     cp $DIR/../bio/tutorial/malariamine.properties $PROP_FILE
-    sed -i '' "s/PSQL_USER/$PSQL_USER/g" $PROP_FILE
-    sed -i '' "s/PSQL_PWD/$PSQL_PWD/g" $PROP_FILE
-    sed -i '' "s/TOMCAT_USER/$TOMCAT_USER/g" $PROP_FILE
-    sed -i '' "s/TOMCAT_PWD/$TOMCAT_PWD/g" $PROP_FILE
-    sed -i '' "s/items-malariamine/$ITEMS_DB/g" $PROP_FILE
-    sed -i '' "s/userprofile-malariamine/$USERPROFILE_DB/g" $PROP_FILE
-    sed -i '' "s/databaseName=malariamine/databaseName=$PROD_DB/g" $PROP_FILE
-    sed -i '' "s/malariamine/$MINENAME/gi" $PROP_FILE
-    sed -i '' "s/localhost/$SERVER/g" $PROP_FILE
-    sed -i '' "s/8080/$PORT/g" $PROP_FILE
+    sed -i=bak "s/PSQL_USER/$PSQL_USER/g" $PROP_FILE
+    sed -i=bak "s/PSQL_PWD/$PSQL_PWD/g" $PROP_FILE
+    sed -i=bak "s/TOMCAT_USER/$TOMCAT_USER/g" $PROP_FILE
+    sed -i=bak "s/TOMCAT_PWD/$TOMCAT_PWD/g" $PROP_FILE
+    sed -i=bak "s/items-malariamine/$ITEMS_DB/g" $PROP_FILE
+    sed -i=bak "s/userprofile-malariamine/$USERPROFILE_DB/g" $PROP_FILE
+    sed -i=bak "s/databaseName=malariamine/databaseName=$PROD_DB/g" $PROP_FILE
+    sed -i=bak "s/malariamine/$MINENAME/gi" $PROP_FILE
+    sed -i=bak "s/localhost/$SERVER/g" $PROP_FILE
+    sed -i=bak "s/8080/$PORT/g" $PROP_FILE
     echo "#--- Created $PROP_FILE"
 fi
 
@@ -132,8 +132,8 @@ if test ! -f project.xml; then
 fi
 
 echo '#---> Personalising project.xml'
-sed -i '' "s!DATA_DIR!$DATA_DIR!g" project.xml
-sed -i '' "s/malariamine/$MINENAME/g" project.xml
+sed -i=bak "s!DATA_DIR!$DATA_DIR!g" project.xml
+sed -i=bak "s/malariamine/$MINENAME/g" project.xml
 
 if egrep -q ProteinDomain.shortName $PRIORITIES; then
     echo '#--- Integration key exists.'


### PR DESCRIPTION
This is a follow up to the previous correction with sed for the biotestmine https://github.com/intermine/intermine/pull/1389

I used a syntax in #1389 that turned out to not be compatible with linux sed after fixing it for mac. Going back, i saw that testmodel/setup.sh simply used this syntax, and it seems to be a simpler option that works well in both OSs (it is not fully in place editing but not really necessary I think).