### PR TITLE
Remove ProteinDomain.shortName from biotestmine genomic_properties

### DIFF
--- a/biotestmine/dbmodel/resources/genomic_priorities.properties
+++ b/biotestmine/dbmodel/resources/genomic_priorities.properties
@@ -13,7 +13,3 @@
 # Gene.name = flybase, *
 
 
-ProteinDomain.shortName = interpro, uniprot-malaria
-ProteinDomain.shortName = interpro, uniprot-malaria
-ProteinDomain.shortName = interpro, uniprot-malaria
-ProteinDomain.shortName = interpro, uniprot-malaria


### PR DESCRIPTION
This is a follow up to the discussion from https://groups.google.com/forum/#!category-topic/intermine/database-build/oSzjmkgvzOI


In that thread we saw an error in ./biotestmine/setup.sh which came from ant -v -Dsource=uniprot-malaria

```
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.intermine.dataloader.IntegrationWriterFactory.getIntegrationWriter(IntegrationWriterFactory.java:65)
        ... 32 more
Caused by: java.lang.IllegalArgumentException: Problem instantiating IntegrationWriterDataTrackingImpl integration.production
        at org.intermine.dataloader.IntegrationWriterDataTrackingImpl.getInstance(IntegrationWriterDataTrackingImpl.java:145)
        at org.intermine.dataloader.IntegrationWriterDataTrackingImpl.getInstance(IntegrationWriterDataTrackingImpl.java:80)
        ... 37 more
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
        at org.intermine.dataloader.IntegrationWriterDataTrackingImpl.getInstance(IntegrationWriterDataTrackingImpl.java:143)
        ... 38 more
Caused by: java.lang.IllegalArgumentException: Class 'ProteinDomain' not found in model, check priorities configuration file - bad entry is ProteinDomain.shortName.
        at org.intermine.dataloader.PriorityConfig.<init>(PriorityConfig.java:105)
        at org.intermine.dataloader.IntegrationWriterDataTrackingImpl.<init>(IntegrationWriterDataTrackingImpl.java:179)
        ... 43 more
```


To my knowledge this error is due to some changes in how uniprot loaded in 1.6.  I think removing it at least allows biotestmine to be built though!