### PR TITLE
Add fix for popup blocker being triggered on region search results

### DIFF
--- a/bio/webapp/resources/webapp/model/genomic_region_search/genomic_region_search_results_default.js
+++ b/bio/webapp/resources/webapp/model/genomic_region_search/genomic_region_search_results_default.js
@@ -112,12 +112,12 @@
             alert("It is not allowed to create a list with 100,000+ genomic features...");
           } else {
               jQuery.post("genomicRegionSearchAjax.do", { spanUUIDString: span_uuid_string, createList: "true", criteria: criteria, facet: facet }, function(bagName){
-                  // window.location.href = "/" + webapp_path + "/bagDetails.do?bagName=" + bagName;
-                  window.open(
+                  window.location.href = "/" + webapp_path + "/bagDetails.do?bagName=" + bagName;
+                  /*window.open(
                       "/" + webapp_path + "/bagDetails.do?bagName=" + bagName,
                       '_blank' // <- This is what makes it open in a new window.
                       );
-              }, "text");
+              }, "text"); // would use but triggers pop up blocker */
           }
         }, "text");
     }


### PR DESCRIPTION
I've seen that the region search result page ends up triggering the pop-up blocker in many browsers including both the latest chrome and firefox.

There are probably workarounds to make and the pop-up open legitimately, but I figured the easiest thing to do is to actually just open the results in the current tab after hitting the "Go" button, since hitting the back button seems to be fine anyways.

Hopefully by not triggering the popup blocker it would not confuse any users of the service, especially when pop-up blocked results can go unnoticed