### PR TITLE
only return CURRENT public lists

### DIFF
--- a/intermine/api/main/src/org/intermine/api/bag/BagManager.java
+++ b/intermine/api/main/src/org/intermine/api/bag/BagManager.java
@@ -127,6 +127,10 @@ public class BagManager
 
         for (Map.Entry<String, InterMineBag> entry : profile.getSavedBags().entrySet()) {
             InterMineBag bag = entry.getValue();
+            // is this bag useable (current)?
+            if (!bag.isCurrent()) {
+                continue;
+            }
             List<Tag> tags = tagManager.getTags(tag, bag.getName(), TagTypes.BAG,
                     profile.getUsername());
             if (tags.size() > 0) {


### PR DESCRIPTION
Refs #1404

Global lists should always be CURRENT.
Lists per user can be whatever status.

Example:

LIST A should not be included in global lists because it is not current. It would be returned if Rachel logged in and asked for her lists however.