### PR TITLE
specifically escape parens as they are messing up the regex. 

### DIFF
--- a/intermine/api/main/src/org/intermine/api/bag/BagQueryRunner.java
+++ b/intermine/api/main/src/org/intermine/api/bag/BagQueryRunner.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.intermine.InterMineException;
@@ -126,8 +127,10 @@ public class BagQueryRunner
                 // wildcard + a string
                 } else {
                     wildcardInput.add(inputString);
-                    patterns.put(inputString, Pattern.compile(inputString.toLowerCase()
-                            .replaceAll("\\*", "\\.\\*")));
+                    String patternString = inputString.toLowerCase().replaceAll("\\*", "\\.\\*");
+                    patternString = patternString.replaceAll("\\(", "\\.\\*");
+                    patternString = patternString.replaceAll("\\)", "\\.\\*");
+                    patterns.put(inputString, Pattern.compile(patternString));
                 }
             }
         }

--- a/intermine/api/main/src/org/intermine/api/bag/BagQueryRunner.java
+++ b/intermine/api/main/src/org/intermine/api/bag/BagQueryRunner.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.intermine.InterMineException;


### PR DESCRIPTION
Refs #1368 

1. Does not impact list upload (I think?)
2. Does not impact LOOKUP queries that do not contain a wildcard
3. Does not impact LOOKUP queries that do not also contain parenthesis. 

This is a query that errors on the live site but works with my fix:

```
<query name="" model="genomic" view="Gene.secondaryIdentifier Gene.symbol Gene.primaryIdentifier Gene.organism.name" longDescription="" sortOrder="Gene.secondaryIdentifier asc">
  <constraint path="Gene" op="LOOKUP" value="Del(8*"/>
</query>
```

Need to make sure this does not impact search results. e.g. We want to be able to search for parenthesis.