### PR TITLE
Update GenomicRegionSearchService.java

### DIFF
--- a/bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchService.java
+++ b/bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchService.java
@@ -854,7 +854,7 @@ public class GenomicRegionSearchService
                     continue;
                 }
             }
-
+            boolean passed = false; // flag to add to errorSpanList
             if (gr.getStart() > gr.getEnd()) {
                 GenomicRegion newSpan = new GenomicRegion();
                 newSpan.setChr(ci.getChrPID()); // converted to the right case
@@ -869,6 +869,7 @@ public class GenomicRegionSearchService
                 newSpan.setExtendedRegionSize(0);
                 newSpan.setOrganism(grsc.getOrgName());
                 passedSpanList.add(newSpan);
+                passed = true;
             } else {
                 gr.setChr(ci.getChrPID());
 
@@ -877,12 +878,16 @@ public class GenomicRegionSearchService
                 }
 
                 passedSpanList.add(gr);
+                passed = true;
             }
+            // add to errorSpanList here if not passed
+            if (!passed) errorSpanList.add(gr);
         }
 
-        // make errorSpanList
-        errorSpanList.addAll(grsc.getGenomicRegionList());
-        errorSpanList.removeAll(passedSpanList);
+        // make errorSpanList - replaced by logic above using passed flag
+        // NOTE (SH): can't use removeAll(passedSpanList) because the newSpan entries are not members of grsc.getGenomicRegionList()!
+        // errorSpanList.addAll(grsc.getGenomicRegionList());
+        // errorSpanList.removeAll(passedSpanList);
 
         resultMap.put("pass", passedSpanList);
         resultMap.put("error", errorSpanList);


### PR DESCRIPTION
Bug fix - the logic building errorSpanList was faulty, since regions added to passedSpanList after their coordinates are reversed are NOT members of grsc.getGenomicRegionList(). Therefore, all reversed-coordinate (- strand) regions were added to errorSpanList. New logic simply uses a flag "passed" that is set if the region is added to passedSpanList; otherwise, it is added to errorSpanList.

This allows reverse-coordinate regions (- strand) to be analyzed as intended.