### PR TITLE
Add support for strand-specific search

### DIFF
--- a/bio/webapp/src/org/intermine/bio/webservice/GenomicRegionSearchService.java
+++ b/bio/webapp/src/org/intermine/bio/webservice/GenomicRegionSearchService.java
@@ -146,10 +146,11 @@ public class GenomicRegionSearchService extends ListMakerService
      */
     protected Map<GenomicRegion, Query> createQueries(GenomicRegionSearchInfo info) {
         return GenomicRegionSearchUtil.createRegionListQueries(
-                info.getGenomicRegions(),
-                info.getExtension(),
-                GenomicRegionSearchQueryRunner.getChromosomeInfo(im).get(info.getOrganism()),
-                info.getOrganism(),
-                info.getFeatureClasses());
+                                                               info.getGenomicRegions(),
+                                                               info.getExtension(),
+                                                               GenomicRegionSearchQueryRunner.getChromosomeInfo(im).get(info.getOrganism()),
+                                                               info.getOrganism(),
+                                                               info.getFeatureClasses(),
+                                                               info.getStrandSpecific());
     }
 }


### PR DESCRIPTION
Part of Genomic Region Search update to allow strand-specific searches. All eight files must be committed together:
modified: bio/webapp/resources/webapp/model/genomicRegionSearchOptionsBase.jsp
modified: bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchService.java
modified: bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchUtil.java
modified: bio/webapp/src/org/intermine/bio/web/model/GenomicRegion.java
modified: bio/webapp/src/org/intermine/bio/web/model/GenomicRegionSearchConstraint.java
modified: bio/webapp/src/org/intermine/bio/web/struts/GenomicRegionSearchAction.java
modified: bio/webapp/src/org/intermine/bio/webservice/GenomicRegionSearchListInput.java
modified: bio/webapp/src/org/intermine/bio/webservice/GenomicRegionSearchService.java
