### PR TITLE
Widget constraints

### DIFF
--- a/intermine/web/main/src/org/intermine/web/logic/widget/GraphWidget.java
+++ b/intermine/web/main/src/org/intermine/web/logic/widget/GraphWidget.java
@@ -16,11 +16,14 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 import org.intermine.metadata.ClassDescriptor;
+import org.intermine.metadata.ConstraintOp;
 import org.intermine.api.profile.InterMineBag;
 import org.intermine.objectstore.ObjectStore;
 import org.intermine.pathquery.Constraints;
+import org.intermine.pathquery.PathConstraint;
 import org.intermine.pathquery.PathQuery;
 import org.intermine.web.logic.widget.config.GraphWidgetConfig;
+import org.intermine.web.logic.widget.config.WidgetConfigUtil;
 
 /**
  * @author Xavier Watkins
@@ -172,6 +175,19 @@ public class GraphWidget extends Widget
                                           "%series"));
         }
 
+        //constraints set in the constraints attribute
+        List<PathConstraint> pathConstraints = config.getPathConstraints();
+        for (PathConstraint pc : pathConstraints) {
+            if (!WidgetConfigUtil.isFilterConstraint(config, pc)) {
+                if (pc.getOp().equals(ConstraintOp.EQUALS)) {
+                    q.addConstraint(Constraints.eq(prefix + pc.getPath(),
+                            PathConstraint.getValue(pc)));
+                } else if (pc.getOp().equals(ConstraintOp.NOT_EQUALS)) {
+                    q.addConstraint(Constraints.neq(prefix + pc.getPath(),
+                            PathConstraint.getValue(pc)));
+                }
+            }
+        }
         return q;
     }
 

--- a/intermine/web/main/src/org/intermine/web/logic/widget/GraphWidgetLoader.java
+++ b/intermine/web/main/src/org/intermine/web/logic/widget/GraphWidgetLoader.java
@@ -226,10 +226,10 @@ public class GraphWidgetLoader extends WidgetLdr implements DataSetLdr
                 if (queryValue != null) {
                     if (!"null".equalsIgnoreCase(queryValue.getValue().toString())) {
                         QueryEvaluable qe = null;
-                        if (isFilterConstraint || queryValue.getValue() instanceof Boolean) {
-                            qe = qfConstraint;
-                        } else {
+                        if ( queryValue.getValue() instanceof String && !isFilterConstraint) {
                             qe = new QueryExpression(QueryExpression.LOWER, qfConstraint);
+                        } else {
+                            qe = qfConstraint;
                         }
                         cs.addConstraint(new SimpleConstraint(qe, pc.getOp(), queryValue));
                     } else {

--- a/intermine/web/main/src/org/intermine/web/logic/widget/WidgetLdr.java
+++ b/intermine/web/main/src/org/intermine/web/logic/widget/WidgetLdr.java
@@ -13,6 +13,7 @@ package org.intermine.web.logic.widget;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.log4j.Logger;
 import org.intermine.api.profile.InterMineBag;
 import org.intermine.objectstore.ObjectStore;
@@ -89,7 +90,15 @@ public class WidgetLdr
         } else if ("false".equalsIgnoreCase(value)) {
             queryValue = new QueryValue(false);
         } else {
-            queryValue = new QueryValue(value);
+            if (!NumberUtils.isNumber(value)) {
+                queryValue = new QueryValue(value);
+            } else {
+                try {
+                    queryValue = new QueryValue(Integer.parseInt(value));
+                } catch (NumberFormatException nfe) {
+                    queryValue = new QueryValue(Double.parseDouble(value));
+                }
+            }
         }
         return queryValue;
     }

--- a/intermine/web/test/resources/WebConfigTest.xml
+++ b/intermine/web/test/resources/WebConfigTest.xml
@@ -23,7 +23,21 @@
     <tabledisplayer src="/model/tableManager.jsp"/>
   </class>
    <widgets>
-   <enrichmentwidgetdisplayer id="contractor_enrichment"
+        <graphdisplayer id="age_groups"
+                      title="Age Groups Distribution"
+                      description="Demographic distribution of employees by age group"
+                      graphType="ColumnChart"
+                      domainLabel="Age group"
+                      rangeLabel="Count"
+                      startClass="Employee"
+                      typeClass="Employee"
+                      categoryPath="age"
+                      seriesPath=""
+                      seriesValues=""
+                      seriesLabels=""
+                      constraints="age != 40"
+                      views="name,age,fullTime,department.name"/>
+        <enrichmentwidgetdisplayer id="contractor_enrichment"
                  title="Contractor Enrichment"
                  label="Contractor"
                  description="The relationship between contractors and employees"

--- a/intermine/web/test/src/org/intermine/web/logic/widget/GraphWidgetTest.java
+++ b/intermine/web/test/src/org/intermine/web/logic/widget/GraphWidgetTest.java
@@ -1,0 +1,95 @@
+package org.intermine.web.logic.widget;
+
+import java.util.List;
+import java.util.Map;
+
+/*
+ * Copyright (C) 2002-2016 FlyMine
+ *
+ * This code may be freely distributed and modified under the
+ * terms of the GNU Lesser General Public Licence.  This should
+ * be distributed with the code.  See the LICENSE file for more
+ * information or http://www.gnu.org/copyleft/lesser.html.
+ *
+ */
+
+import org.intermine.api.profile.InterMineBag;
+import org.intermine.pathquery.Constraints;
+import org.intermine.pathquery.PathConstraint;
+import org.intermine.pathquery.PathQuery;
+import org.intermine.web.logic.widget.config.EnrichmentWidgetConfig;
+import org.intermine.web.logic.widget.config.GraphWidgetConfig;
+import org.intermine.web.logic.widget.config.WidgetConfig;
+import org.junit.Ignore;
+
+public class GraphWidgetTest extends WidgetConfigTestCase
+{
+    private final class GraphOptions implements WidgetOptions {
+        @Override
+        public String getFilter() {
+            return null;
+        }
+    }
+    private GraphWidget widget;
+    private InterMineBag bag;
+    private WidgetConfig config;
+    private WidgetOptions options;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        config = webConfig.getWidgets().get("age_groups");
+        InterMineBag employeeList = createEmployeeLongList();
+        bag = employeeList;
+        options = new GraphOptions();
+        widget = new GraphWidget((GraphWidgetConfig) config, bag, os, options, null);
+    }
+
+    public void testContraintIntegerType() throws Exception {
+        widget.process();
+        List<List<Object>> results = widget.getResults();
+
+        //first element contain the range label Count
+        //[25][1]
+        assertEquals("25", results.get(1).get(0).toString());
+        assertEquals("1", results.get(1).get(1).toString());
+        //[35][1]
+        assertEquals("35", results.get(2).get(0).toString());
+        assertEquals("2", results.get(2).get(1).toString());
+        //[50][1]
+        assertEquals("50", results.get(3).get(0).toString());
+        assertEquals("1", results.get(3).get(1).toString());
+    }
+
+/*   public void testGetPathQuery() {
+        PathQuery q = new PathQuery(os.getModel());
+        q.addView("Employee.name");
+        q.addView("Employee.age");
+        q.addView("Employee.fullTime");
+        q.addView("Employee.department.name");
+        // bag constraint
+        q.addConstraint(Constraints.in(config.getStartClass(), bag.getName()));
+        q.addConstraint(Constraints.neq("Employee.age", "40"));
+        PathQuery widgetPathQuery = widget.getPathQuery();
+        assertEquals(q, widgetPathQuery);
+    }*/
+
+    public void testCreatePathQueryView() {
+        PathQuery pathQuery = new PathQuery(os.getModel());
+        pathQuery.addView("Employee.name");
+        pathQuery.addView("Employee.age");
+        pathQuery.addView("Employee.fullTime");
+        pathQuery.addView("Employee.department.name");
+        assertEquals(pathQuery, widget.createPathQueryView(os,
+                webConfig.getWidgets().get(("age_groups"))));
+    }
+
+    public void testValidateBagType() throws Exception {
+        InterMineBag companyList = createCompanyList();
+        try {
+            widget = new GraphWidget((GraphWidgetConfig) config, companyList, os, options, null);
+            widget.process();
+            fail("Should raise a IllegalArgumentException");
+        } catch (IllegalArgumentException iae){
+        }
+    }
+}

--- a/intermine/web/test/src/org/intermine/web/logic/widget/GraphWidgetTest.java
+++ b/intermine/web/test/src/org/intermine/web/logic/widget/GraphWidgetTest.java
@@ -60,7 +60,7 @@ public class GraphWidgetTest extends WidgetConfigTestCase
         assertEquals("1", results.get(3).get(1).toString());
     }
 
-/*   public void testGetPathQuery() {
+   public void testGetPathQuery() {
         PathQuery q = new PathQuery(os.getModel());
         q.addView("Employee.name");
         q.addView("Employee.age");
@@ -68,10 +68,11 @@ public class GraphWidgetTest extends WidgetConfigTestCase
         q.addView("Employee.department.name");
         // bag constraint
         q.addConstraint(Constraints.in(config.getStartClass(), bag.getName()));
+        q.addConstraint(Constraints.eq("Employee.age", "%category"));
         q.addConstraint(Constraints.neq("Employee.age", "40"));
         PathQuery widgetPathQuery = widget.getPathQuery();
         assertEquals(q, widgetPathQuery);
-    }*/
+    }
 
     public void testCreatePathQueryView() {
         PathQuery pathQuery = new PathQuery(os.getModel());

--- a/intermine/web/test/src/org/intermine/web/logic/widget/WidgetConfigTestCase.java
+++ b/intermine/web/test/src/org/intermine/web/logic/widget/WidgetConfigTestCase.java
@@ -67,8 +67,12 @@ public class WidgetConfigTestCase extends InterMineAPITestCase {
             osw = ObjectStoreWriterFactory.getObjectStoreWriter("osw.unittest");
             Employee e1 = new Employee();
             e1.setName("Employee1");
+            e1.setAge(25);
+            e1.setFullTime(true);
             Employee e2 = new Employee();
             e2.setName("Employee2");
+            e2.setAge(35);
+            e2.setFullTime(true);
             Department d1 = new Department();
             d1.setName("department");
             Company company = new CompanyShadow();
@@ -87,6 +91,62 @@ public class WidgetConfigTestCase extends InterMineAPITestCase {
             InterMineBag list = superUser.createBag("employeeList", "Employee", "", im.getClassKeys());
             Collection<Integer> ids = new ArrayList<Integer>();
             ids.add(e1.getId()); ids.add(e2.getId());
+            list.addIdsToBag(ids, "Employee");
+            return list;
+        } finally {
+            osw.close();
+        }
+    }
+
+    protected InterMineBag createEmployeeLongList() throws Exception {
+        ObjectStoreWriter osw = null;
+        try {
+            Profile superUser = im.getProfileManager().getSuperuserProfile();
+            osw = ObjectStoreWriterFactory.getObjectStoreWriter("osw.unittest");
+            Employee e1 = new Employee();
+            e1.setName("Employee1");
+            e1.setAge(25);
+            e1.setFullTime(true);
+            Employee e2 = new Employee();
+            e2.setName("Employee2");
+            e2.setAge(35);
+            e2.setFullTime(true);
+            Employee e3 = new Employee();
+            e3.setName("Employee1");
+            e3.setAge(35);
+            e3.setFullTime(true);
+            Employee e4 = new Employee();
+            e4.setName("Employee1");
+            e4.setAge(40);
+            e4.setFullTime(true);
+            Employee e5 = new Employee();
+            e5.setName("Employee1");
+            e5.setAge(50);
+            e5.setFullTime(true);
+            Department d1 = new Department();
+            d1.setName("department");
+            Company company = new CompanyShadow();
+            company.setName("company");
+            Contractor contractor = new Contractor();
+            contractor.setName("contractor");
+            osw.store(contractor);
+            company.addContractors(contractor);
+            osw.store(company);
+            d1.setCompany(company);
+            osw.store(d1);
+            e1.setDepartment(d1);
+            e2.setDepartment(d1);
+            e3.setDepartment(d1);
+            e4.setDepartment(d1);
+            e5.setDepartment(d1);
+            osw.store(e1);
+            osw.store(e2);
+            osw.store(e3);
+            osw.store(e4);
+            osw.store(e5);
+            InterMineBag list = superUser.createBag("employeeList", "Employee", "", im.getClassKeys());
+            Collection<Integer> ids = new ArrayList<Integer>();
+            ids.add(e1.getId()); ids.add(e2.getId()); ids.add(e3.getId()); ids.add(e4.getId()); ids.add(e5.getId());
             list.addIdsToBag(ids, "Employee");
             return list;
         } finally {


### PR DESCRIPTION
Fixed the bug in the graph widget. Now the user can set e.g. in the flyatlas_for_gene widget, the attribute constraint as  "presentCall != 0, presentCall != 1, presentCall != 2". The valid operators are still "=" and "!="