### PR TITLE
point to newest version of cytoscape script to address ...

### DIFF
--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -146,8 +146,8 @@ head.js.pathways-displayer._ = CDN/js/underscore.js/1.4.4/underscore-min.js
 head.js.pathways-displayer.Backbone = CDN/js/backbone.js/1.1.0/backbone-min.js
 
 # Cytoscape Gene Interaction Displayer on Report Page
-head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.4/gene-interaction-displayer.js
-head.css.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.4/gene-interaction-displayer.css
+head.js.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.5/gene-interaction-displayer.js
+head.css.gene-interaction-displayer.main = CDN/js/intermine/gene-interaction-displayer/1.0.5/gene-interaction-displayer.css
 
 # Complex viewer Displayer on Report Page
 head.js.complex-viewer.main = CDN/js/complexviewer/1.0.4/complexviewer.min.js


### PR DESCRIPTION
https://github.com/intermine/intermine/issues/1445 - too many interactions cause the browser to crash in proteins. Fixed by simply preventing the graph from rendering client-side when there are more than 500 interactions, and giving an appropriate error message. 

No one wanted those spaghetti hairball graphs anyway