### PR TITLE
Allow the name attribute to be missing

### DIFF
--- a/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
@@ -207,7 +207,7 @@ public class OboConverter extends DataConverter
      */
     protected void configureItem(String termId, Item item, OboTerm term)
         throws ObjectStoreException {
-        if (term.getName()!=null && term.getName().trim().length()>0) {
+        if (term.getName() != null && term.getName().trim().length() > 0) {
             item.addAttribute(new Attribute("name", term.getName()));
         }
         item.addReference(new Reference("ontology", ontology.getIdentifier()));

--- a/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
@@ -207,7 +207,9 @@ public class OboConverter extends DataConverter
      */
     protected void configureItem(String termId, Item item, OboTerm term)
         throws ObjectStoreException {
-        item.addAttribute(new Attribute("name", term.getName()));
+        if (term.getName()!=null && term.getName().trim().length()>0) {
+            item.addAttribute(new Attribute("name", term.getName()));
+        }
         item.addReference(new Reference("ontology", ontology.getIdentifier()));
         if (term.getId() != null) {
             item.addAttribute(new Attribute("identifier", term.getId()));


### PR DESCRIPTION
Some OBO files have terms which are missing the name attribute. The code assumed that it exists, and the import therefore threw a fatal RunException when it hit a term which had a blank name attribute. This update simply tests for existence first, just as it already did for identifier (which, I thought, actually IS required in an OBO!).