### PR TITLE
Fix a caching bug in strand specific region search where searches on …

### DIFF
--- a/bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchService.java
+++ b/bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchService.java
@@ -866,11 +866,13 @@ public class GenomicRegionSearchService
                 gr.setStart(grEnd);
                 gr.setEnd(grStart);
 
-                if (grsc.getStrandSpecific())
+                if (grsc.getStrandSpecific()) {
                     gr.setStrand(-1);
+                }
             } else {
-                if (grsc.getStrandSpecific())
+                if (grsc.getStrandSpecific()) {
                     gr.setStrand(1);
+                }
             }
 
             if (gr.getStart() < 1) {

--- a/bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchService.java
+++ b/bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchService.java
@@ -857,35 +857,27 @@ public class GenomicRegionSearchService
                 }
             }
 
-            boolean passed = false; // flag to add to errorSpanList
+            gr.setChr(ci.getChrPID()); // converted to the right case
+
             if (gr.getStart() > gr.getEnd()) {
-                gr.setChr(ci.getChrPID()); // converted to the right case
                 // swap start, end and flag as minus strand
                 Integer grStart = gr.getStart();
                 Integer grEnd = gr.getEnd();
                 gr.setStart(grEnd);
                 gr.setEnd(grStart);
-                gr.setMinusStrand(Boolean.TRUE);
-                if (gr.getStart() < 1) {
-                    gr.setStart(1);
-                }
-                passedSpanList.add(gr);
-                passed = true;
+
+                if (grsc.getStrandSpecific())
+                    gr.setStrand(-1);
             } else {
-                gr.setChr(ci.getChrPID());
-                if (gr.getStart() < 1) {
-                    gr.setStart(1);
-                }
-                gr.setMinusStrand(Boolean.FALSE);
-                passedSpanList.add(gr);
-                passed = true;
+                if (grsc.getStrandSpecific())
+                    gr.setStrand(1);
             }
 
-            // add to errorSpanList here if not passed; shouldn't ever happen, but we'll keep it
-            // for now for back-compatibility
-            if (!passed) {
-                errorSpanList.add(gr);
+            if (gr.getStart() < 1) {
+                gr.setStart(1);
             }
+
+            passedSpanList.add(gr);
         }
 
         // make errorSpanList - replaced by logic above using passed flag

--- a/bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchUtil.java
+++ b/bio/webapp/src/org/intermine/bio/web/logic/GenomicRegionSearchUtil.java
@@ -149,8 +149,6 @@ public final class GenomicRegionSearchUtil
         }
         region.setEnd(end);
 
-        region.setMinusStrand(start > end);
-
         ChromosomeInfo ci = getChromosomeInfo(chromsForOrg, region.getChr());
 
         if ((region.getStart() >= 1 && region.getStart() <= ci.getChrLength())
@@ -351,13 +349,10 @@ public final class GenomicRegionSearchUtil
             constraints.addConstraint(ccLocObject);
 
             // Location.strand = strand (optional)
-            if (strandSpecific) {
-                String strand = "1";
-                if (aSpan.getMinusStrand()) {
-                    strand = "-1";
-                }
+            int strand = aSpan.getStrand();
+            if (strand != 0) {
                 SimpleConstraint scStrand = new SimpleConstraint(qfLocStrand, ConstraintOp.EQUALS,
-                        new QueryValue(strand));
+                        new QueryValue(Integer.toString(strand)));
                 constraints.addConstraint(scStrand);
             }
 
@@ -466,7 +461,6 @@ public final class GenomicRegionSearchUtil
                     gr.setStart(Integer.valueOf(start));
                     gr.setEnd(Integer.valueOf(end));
                     gr.setExtendedRegionSize(0);
-                    gr.setMinusStrand(gr.getStart() > gr.getEnd());
                     genomicRegionList.add(gr);
                 } else {
                     throw new Exception("Not Dot-Dot format: " + original);
@@ -491,7 +485,6 @@ public final class GenomicRegionSearchUtil
                         gr.setExtendedStart(Integer.valueOf(extStart));
                         gr.setExtendedEnd(Integer.valueOf(extEnd));
                         gr.setExtendedRegionSize(Integer.valueOf(extenedSize));
-                        gr.setMinusStrand(gr.getStart() > gr.getEnd());
                         genomicRegionList.add(gr);
                     } else {
                         throw new Exception("Not Dot-Dot format: " + original);
@@ -501,72 +494,6 @@ public final class GenomicRegionSearchUtil
         }
 
         return genomicRegionList;
-    }
-
-    /**
-     * Create a list of GenomicRegion objects from a collection of region strings
-     * @param regionStringList list of region strings
-     * @param organism short name
-     * @param extendedRegionSize flanking
-     * @param isInterBaseCoordinate inter base
-     * @return a list of GenomicRegion objects
-     */
-    public static List<GenomicRegion> createGenomicRegionsFromString(
-            Collection<String> regionStringList, String organism, Integer extendedRegionSize,
-            Boolean isInterBaseCoordinate) {
-        List<GenomicRegion> grList = new ArrayList<GenomicRegion>();
-        for (String grStr : regionStringList) {
-            GenomicRegion aSpan = new GenomicRegion();
-            aSpan.setOrganism(organism);
-            if (extendedRegionSize != null) {
-                aSpan.setExtendedRegionSize(extendedRegionSize);
-            }
-
-            if (DOT_DOT.matcher(grStr).find()) {
-                aSpan.setChr((grStr.split(":"))[0]);
-                String[] spanItems = (grStr.split(":"))[1].split("\\..");
-                String start = spanItems[0].trim();
-                if (isInterBaseCoordinate) {
-                    aSpan.setStart(Integer.valueOf(start) + 1);
-                } else {
-                    aSpan.setStart(Integer.valueOf(start));
-                }
-                aSpan.setEnd(Integer.valueOf(spanItems[1]));
-            } else if (BED.matcher(grStr).find()) {
-                String[] spanItems = grStr.split("\t");
-                aSpan.setChr(spanItems[0]);
-                if (isInterBaseCoordinate) {
-                    aSpan.setStart(Integer.valueOf(spanItems[1]) + 1);
-                } else {
-                    aSpan.setStart(Integer.valueOf(spanItems[1]));
-                }
-                aSpan.setEnd(Integer.valueOf(spanItems[2]));
-            } else if (DASH.matcher(grStr).find()) {
-                aSpan.setChr((grStr.split(":"))[0]);
-                String[] spanItems = (grStr.split(":"))[1].split("-");
-                String start = spanItems[0].trim();
-                if (isInterBaseCoordinate) {
-                    aSpan.setStart(Integer.valueOf(start) + 1);
-                } else {
-                    aSpan.setStart(Integer.valueOf(start));
-                }
-                aSpan.setEnd(Integer.valueOf(spanItems[1]));
-            } else if (SINGLE_POS.matcher(grStr).find()) {
-                aSpan.setChr((grStr.split(":"))[0]);
-                String start = (grStr.split(":"))[1].trim();
-                if (isInterBaseCoordinate) {
-                    aSpan.setStart(Integer.valueOf(start) + 1);
-                } else {
-                    aSpan.setStart(Integer.valueOf(start));
-                }
-                aSpan.setEnd(Integer.valueOf((grStr.split(":"))[1].trim()));
-            } else {
-                throw new IllegalArgumentException("Region string is in wrong format: " + grStr);
-            }
-            aSpan.setMinusStrand(aSpan.getStart() > aSpan.getEnd());
-            grList.add(aSpan);
-        }
-        return grList;
     }
 
     /**

--- a/bio/webapp/src/org/intermine/bio/web/model/GenomicRegion.java
+++ b/bio/webapp/src/org/intermine/bio/web/model/GenomicRegion.java
@@ -25,8 +25,7 @@ public class GenomicRegion implements Comparable<GenomicRegion>
     private Integer extendedRegionSize = new Integer(0); // user add region flanking
     private Integer extendedStart;
     private Integer extendedEnd;
-
-    private Boolean minusStrand;    // for strand-specific matching
+    private int strand;
 
     //user identifier to tag the order of input e.g. X:7880589..7880644:5 is the 5th input
     private Integer tag = null;
@@ -124,6 +123,14 @@ public class GenomicRegion implements Comparable<GenomicRegion>
         this.extendedEnd = extendedEnd;
     }
 
+    public void setStrand(int strand) {
+        this.strand = strand;
+    }
+
+    public int getStrand() {
+        return this.strand;
+    }
+
     /**
      * @return the extendedRegionSize
      */
@@ -150,27 +157,6 @@ public class GenomicRegion implements Comparable<GenomicRegion>
      */
     public Integer getTag() {
         return tag;
-    }
-
-    /**
-     * @param minusStrand as Boolean
-     */
-    public void setMinusStrand(Boolean minusStrand) {
-        this.minusStrand = minusStrand;
-    }
-
-    /**
-     * @param minusStrand as boolean
-     */
-    public void setMinusStrand(boolean minusStrand) {
-        this.minusStrand = minusStrand;
-    }
-
-    /**
-     * @return minusStrand value
-     */
-    public Boolean getMinusStrand() {
-        return minusStrand;
     }
 
     /**
@@ -213,16 +199,19 @@ public class GenomicRegion implements Comparable<GenomicRegion>
             if (gr.getOrganism() == null || gr.getTag() == null) { // for simpler version
                 return (chr.equals(gr.getChr())
                         && start.equals(gr.getStart())
-                        && end.equals(gr.getEnd()));
+                        && end.equals(gr.getEnd())
+                        && strand == gr.getStrand());
             } else {                                               // for full version
                 return (chr.equals(gr.getChr())
                         && start.equals(gr.getStart())
                         && end.equals(gr.getEnd())
                         && organism.equals(gr.getOrganism())
                         && extendedRegionSize.equals(gr.getExtendedRegionSize())
-                        && tag == gr.getTag());
+                        && tag == gr.getTag()
+                        && strand == gr.getStrand());
             }
         }
+
         return false;
     }
 

--- a/bio/webapp/src/org/intermine/bio/web/model/GenomicRegion.java
+++ b/bio/webapp/src/org/intermine/bio/web/model/GenomicRegion.java
@@ -123,10 +123,18 @@ public class GenomicRegion implements Comparable<GenomicRegion>
         this.extendedEnd = extendedEnd;
     }
 
+    /**
+     * Set strand
+     * @param strand 1 is positive, -1 is negative, 0 is both
+     */
     public void setStrand(int strand) {
         this.strand = strand;
     }
 
+    /**
+     * Get strand
+     * @return 1 is positive, -1 is negative, 0 is both
+     */
     public int getStrand() {
         return this.strand;
     }

--- a/bio/webapp/src/org/intermine/bio/web/struts/GenomicRegionSearchAction.java
+++ b/bio/webapp/src/org/intermine/bio/web/struts/GenomicRegionSearchAction.java
@@ -132,7 +132,6 @@ public class GenomicRegionSearchAction extends InterMineAction
                         gr.setChr(coord.split("\t")[0].trim());
                         gr.setStart(Integer.valueOf(coord.split("\t")[1].trim()));
                         gr.setEnd(Integer.valueOf(coord.split("\t")[2].trim()));
-                        gr.setMinusStrand(gr.getStart().intValue() > gr.getEnd().intValue());
                         liftedList.add(gr);
                     }
 


### PR DESCRIPTION
…different strands for the same region in a session would always return the first search results

This involves some restructing so that strands can be set to negative, both and positive on genomic region classes
and the strand setting is used when comparing whether two genomic regions are equal (rather than just if any stranding was requested)