### PR TITLE
Include google profile scope in oauth2 workflow

### DIFF
--- a/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/global.web.properties
@@ -408,7 +408,7 @@ web.templates.expandonload=false
 web.collections.expandonload=true
 
 # OAuth2 config which is common to all applications.
-oauth2.GOOGLE.scopes = openid email
+oauth2.GOOGLE.scopes = openid email profile
 oauth2.GOOGLE.id-key = sub
 oauth2.GOOGLE.identity-resource = https://www.googleapis.com/plus/v1/people/me/openIdConnect
 oauth2.GITHUB.scopes = user:email


### PR DESCRIPTION
Older Google accounts use the `openid` scope to resolve the _name_ field which is stored in the UserPreferences table as _alias_. Under this scope, newer Google accounts have empty string values in these fields hence the error:

`Error granting permission: No two users may have the same value for 'alias', but the value '' is already taken`

By adding the `profile` scope we expose the _name_ field in the oAuth2 response for newer accounts.

A side effect of adding this scope is that Google users will be prompted to re-grant permission to access their basic profile information.