### PR TITLE
allow for multiple xrefs Refs #1545

### DIFF
--- a/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/OboConverter.java
@@ -48,7 +48,7 @@ public class OboConverter extends DataConverter
     protected Collection<OboTerm> oboTerms;
     protected List<OboRelation> oboRelations;
     protected Map<String, Item> nameToTerm = new HashMap<String, Item>();
-    protected Map<String, String> xrefs = new HashMap<String, String>();
+    protected Map<String, Item> xrefs = new HashMap<String, Item>();
     protected Map<OboTermSynonym, Item> synToItem = new HashMap<OboTermSynonym, Item>();
     protected Item ontology;
     private boolean createRelations = true;
@@ -137,6 +137,9 @@ public class OboConverter extends DataConverter
         for (Item synItem : synToItem.values()) {
             store(synItem);
         }
+        for (Item xref : xrefs.values()) {
+            store(xref);
+        }
         long timeTaken = System.currentTimeMillis() - startTime;
         LOG.info("Ran storeItems, took: " + timeTaken + " ms");
     }
@@ -223,16 +226,15 @@ public class OboConverter extends DataConverter
         }
         for (OboTerm xref : term.getXrefs()) {
             String identifier = xref.getId();
-            String refId = xrefs.get(identifier);
-            if (refId == null) {
-                Item xrefTerm = createItem("OntologyTerm");
-                refId = xrefTerm.getIdentifier();
-                xrefs.put(identifier, refId);
+            Item xrefTerm = xrefs.get(identifier);
+            if (xrefTerm == null) {
+                xrefTerm = createItem("OntologyTerm");
+                xrefs.put(identifier, xrefTerm);
                 xrefTerm.setAttribute("identifier", identifier);
-                xrefTerm.addToCollection("crossReferences", item.getIdentifier());
-                store(xrefTerm);
             }
-            item.addToCollection("crossReferences", refId);
+            // many to many so you have to set both ends of the relationship
+            xrefTerm.addToCollection("crossReferences", item.getIdentifier());
+            item.addToCollection("crossReferences", xrefTerm);
         }
         OboTerm oboterm = term;
         if (!StringUtils.isEmpty(oboterm.getNamespace())) {


### PR DESCRIPTION
Allow for multiple xrefs Refs #1545

I keep the xrefs in a map and store at the end of the process. This ensures the xrefs have references to ALL ontology terms, not just the first one!

@JoelRichardson Can you test this?

