### PR TITLE
allow each GFF source to specify their own config file. Refs #1325

### DIFF
--- a/bio/core/main/src/org/intermine/bio/dataconversion/GFF3Converter.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/GFF3Converter.java
@@ -31,8 +31,9 @@ import org.intermine.dataconversion.DataConverter;
 import org.intermine.dataconversion.ItemWriter;
 import org.intermine.metadata.ClassDescriptor;
 import org.intermine.metadata.Model;
-import org.intermine.objectstore.ObjectStoreException;
+import org.intermine.metadata.StringUtil;
 import org.intermine.metadata.TypeUtil;
+import org.intermine.objectstore.ObjectStoreException;
 import org.intermine.xml.full.Item;
 import org.intermine.xml.full.Reference;
 
@@ -112,17 +113,32 @@ public class GFF3Converter extends DataConverter
         readConfig();
     }
 
+    // default is gff_config.properties, but can be overridden by a property file for the
+    // specific GFF3 source
+    private String getSourceConfig() {
+        final String suffix = "GFF3RecordHandler";
+        String fullSourceName = handler.getClass().getSimpleName();
+        // chop off suffix, e.g. LongOligoGFF3RecordHandler
+        String shortenedName = fullSourceName.substring(0, fullSourceName.length()
+                - suffix.length());
+        return StringUtil.getFlattenedSourceName(shortenedName) + "_config.properties";
+    }
+
     /**
      * read in config file
      */
     protected void readConfig() {
         Properties gffConfig = new Properties();
         try {
-            gffConfig.load(getClass().getClassLoader().getResourceAsStream(
-                    PROP_FILE));
-        } catch (IOException e) {
-            throw new RuntimeException("I/O Problem loading properties '"
-                    + PROP_FILE + "'", e);
+            gffConfig.load(handler.getClass().getClassLoader().getResourceAsStream(
+                    getSourceConfig()));
+        } catch (Exception e) {
+            try {
+                gffConfig.load(getClass().getClassLoader().getResourceAsStream(PROP_FILE));
+            } catch (IOException e2) {
+                throw new RuntimeException("I/O Problem loading properties '"
+                        + PROP_FILE + "'", e2);
+            }
         }
 
         for (Map.Entry<Object, Object> entry : gffConfig.entrySet()) {

--- a/bio/core/main/src/org/intermine/bio/dataconversion/GFF3Converter.java
+++ b/bio/core/main/src/org/intermine/bio/dataconversion/GFF3Converter.java
@@ -115,7 +115,7 @@ public class GFF3Converter extends DataConverter
 
     // default is gff_config.properties, but can be overridden by a property file for the
     // specific GFF3 source
-    private String getSourceConfig() {
+    private String getConfigFilename() {
         final String suffix = "GFF3RecordHandler";
         String fullSourceName = handler.getClass().getSimpleName();
         // chop off suffix, e.g. LongOligoGFF3RecordHandler
@@ -129,15 +129,23 @@ public class GFF3Converter extends DataConverter
      */
     protected void readConfig() {
         Properties gffConfig = new Properties();
+        final String configFileName = getConfigFilename();
         try {
-            gffConfig.load(handler.getClass().getClassLoader().getResourceAsStream(
-                    getSourceConfig()));
+            // test for red-fly_config.properties
+            gffConfig.load(handler.getClass().getClassLoader().getResourceAsStream(configFileName));
         } catch (Exception e) {
             try {
-                gffConfig.load(getClass().getClassLoader().getResourceAsStream(PROP_FILE));
-            } catch (IOException e2) {
-                throw new RuntimeException("I/O Problem loading properties '"
-                        + PROP_FILE + "'", e2);
+                // test for redfly_config.properties. no dashes
+                final String cleanString = configFileName.replace("-", "");
+                gffConfig.load(getClass().getClassLoader().getResourceAsStream(cleanString));
+            } catch (Exception e3) {
+                try {
+                    // okay nothing there, use default instead
+                    gffConfig.load(getClass().getClassLoader().getResourceAsStream(PROP_FILE));
+                } catch (IOException e2) {
+                    throw new RuntimeException("I/O Problem loading properties '"
+                            + PROP_FILE + "'", e2);
+                }
             }
         }
 

--- a/bio/skeletons/source/main/resources/${source-name}_config.properties
+++ b/bio/skeletons/source/main/resources/${source-name}_config.properties
@@ -1,0 +1,1 @@
+# Configuration file to handle special properties for this data source.

--- a/bio/skeletons/source/main/resources/.gitignore
+++ b/bio/skeletons/source/main/resources/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/intermine/model/main/src/org/intermine/metadata/StringUtil.java
+++ b/intermine/model/main/src/org/intermine/metadata/StringUtil.java
@@ -36,6 +36,31 @@ public final class StringUtil
     }
 
     /**
+     * Flattens source name. e.g. LongOligo changes to long-oligo
+     *
+     * @param sourceName the String to alter
+     * @return the altered string
+     */
+    public static String getFlattenedSourceName(String sourceName) {
+        if (sourceName == null) {
+            return null;
+        }
+        String[] array = sourceName.split("(?=\\p{Upper})");
+        StringBuilder sb = new StringBuilder();
+        boolean firstWord = true;
+        for (String s : array) {
+            if (!firstWord) {
+                sb.append("-");
+            } else {
+                firstWord = false;
+            }
+            sb.append(s);
+        }
+        String s = sb.toString();
+        return s.toLowerCase();
+    }
+
+    /**
      * Returns the number of occurances of str in target
      *
      * @param str the String to count

--- a/intermine/model/main/src/org/intermine/metadata/StringUtil.java
+++ b/intermine/model/main/src/org/intermine/metadata/StringUtil.java
@@ -49,6 +49,9 @@ public final class StringUtil
         StringBuilder sb = new StringBuilder();
         boolean firstWord = true;
         for (String s : array) {
+            if (StringUtils.isEmpty(s)) {
+                continue;
+            }
             if (!firstWord) {
                 sb.append("-");
             } else {


### PR DESCRIPTION
The GFF3 data source (in bio-core) has a config file in bio/core/resources, gff_config.properties.

This now can be overridden by source-specific config files. e.g. bio/sources/fly/long-oligo/main/resources/long-oligo_config.properties. The source looks for the source specific file first, then uses the default if it's not there. This is consistent with the keys file as well.

1. Make sure properties are correct when (a) there is a source specific file (b) there is not a source specific file and the default GFF3 file is used.
2. Sources without a config file are run correctly.

There is no case where the gff_config.properties file is not there.