### PR TITLE
Handle wildcards in LOOKUP constraints correctly.

### DIFF
--- a/intermine/api/main/src/org/intermine/api/query/MainHelper.java
+++ b/intermine/api/main/src/org/intermine/api/query/MainHelper.java
@@ -660,20 +660,24 @@ public final class MainHelper
                                 + "ObjectStore Query without a BagQueryRunner");
                     }
                     String identifiers = pcl.getValue();
-                    BagQueryResult bagQueryResult;
-                    List<String> identifierList = LOOKUP_TOKENISER.tokenise(identifiers);
-                    try {
-                        bagQueryResult = bagQueryRunner.searchForBag(qc.getType()
-                                .getSimpleName(), identifierList, pcl.getExtraValue(), true);
-                    } catch (ClassNotFoundException e) {
-                        throw new ObjectStoreException(e);
-                    } catch (InterMineException e) {
-                        throw new ObjectStoreException(e);
-                    }
-                    codeToConstraint.put(code, new BagConstraint(new QueryField(qc, "id"),
+                    // if this LOOKUP constraint only includes *, just ignore constraint
+                    // as user wants everything.
+                    if (!"*".equals(identifiers)) {
+                        BagQueryResult bagQueryResult;
+                        List<String> identifierList = LOOKUP_TOKENISER.tokenise(identifiers);
+                        try {
+                            bagQueryResult = bagQueryRunner.searchForBag(qc.getType()
+                                    .getSimpleName(), identifierList, pcl.getExtraValue(), true);
+                        } catch (ClassNotFoundException e) {
+                            throw new ObjectStoreException(e);
+                        } catch (InterMineException e) {
+                            throw new ObjectStoreException(e);
+                        }
+                        codeToConstraint.put(code, new BagConstraint(new QueryField(qc, "id"),
                                 ConstraintOp.IN, bagQueryResult.getMatchAndIssueIds()));
-                    if (returnBagQueryResults != null) {
-                        returnBagQueryResults.put(stringPath, bagQueryResult);
+                        if (returnBagQueryResults != null) {
+                            returnBagQueryResults.put(stringPath, bagQueryResult);
+                        }
                     }
                 } else {
                     throw new ObjectStoreException("Unknown constraint type "


### PR DESCRIPTION
if user enters * into LOOKUP constraint, drop that constraint. They want EVERYTHING. Refs #1471

Test carefully!

* List upload
* Any template or query with a LOOKUP constraint

I didn't touch the bagqueryrunner code (the bit that does the LOOKUP part). That still treats `*` as a string. This is correct behaviour. If someone enters a `*` on the list upload it will be treated like a string. We don't want to make a list of everything!

All I did here was to drop the LOOKUP constraint if it equals `*` in its entirety. This means the constraint won't be there so the query will return all results, which is what the user wanted.

Check my logic!