### PR TITLE
Add the 4 numbers used to calculation the enrichment value

### DIFF
--- a/intermine/web/main/src/org/intermine/web/logic/Constants.java
+++ b/intermine/web/main/src/org/intermine/web/logic/Constants.java
@@ -207,8 +207,9 @@ public final class Constants
      * 18 - Added display names to the model output.
      * 19 - Added intermine version
      * 20 - Added class counts and display names for atts, refs and colls. #1410
+     * 21 - Added populationCounts to enrichment output. #1601
      */
-    public static final int WEB_SERVICE_VERSION = 20;
+    public static final int WEB_SERVICE_VERSION = 21;
 
     /**
      * Current version of the InterMine code

--- a/intermine/web/main/src/org/intermine/web/logic/widget/EnrichmentCalculation.java
+++ b/intermine/web/main/src/org/intermine/web/logic/widget/EnrichmentCalculation.java
@@ -71,11 +71,13 @@ public final class EnrichmentCalculation
                     correctedResults, population, annotatedPopulationInfo, maxValue);
         }
         Map<String, BigDecimal> sortedCorrectedResults = ErrorCorrection.sortMap(correctedResults);
-        // record the number of items in the sample that had any values for the attribute
-        int widgetTotal = rawResults.isEmpty() ? 0 : sampleSize;
+        // record the number of items in the sample that had any values for any attribute
+        // used for the "not analysed" total
+        int analysedTotal = rawResults.isEmpty() ? 0 : sampleSize;
 
         EnrichmentResults results = new EnrichmentResults(sortedCorrectedResults,
-                input.getAnnotatedCountsInSample(), input.getLabels(), widgetTotal);
+                input.getAnnotatedCountsInSample(), input.getLabels(), analysedTotal,
+                annotatedPopulationInfo, populationSize);
 
         return results;
     }

--- a/intermine/web/main/src/org/intermine/web/logic/widget/EnrichmentResults.java
+++ b/intermine/web/main/src/org/intermine/web/logic/widget/EnrichmentResults.java
@@ -25,7 +25,8 @@ public class EnrichmentResults
     private final Map<String, BigDecimal> pValues;
     private final Map<String, Integer> counts;
     private final Map<String, String> labels;
-    private final int analysedTotal;
+    private final Map<String, PopulationInfo> populationAnnotations;
+    private final int analysedTotal, populationTotal;
 
     /**
      * Construct with pre-populated maps from enriched attributes to p-values, counts and labels.
@@ -33,13 +34,20 @@ public class EnrichmentResults
      * @param counts number of items in sample per attribute value
      * @param labels an additional label for each attribute value, used for display
      * @param analysedTotal the number of items in the sample that had data for the given attribute
+     * @param populationAnnotations per GO term, number of genes total in database / background
+     * population annotated
+     * @param populationTotal total size of the population, e.g. count of genes in the database
+     * (or background population)
      */
     protected EnrichmentResults(Map<String, BigDecimal> pValues, Map<String, Integer> counts,
-            Map<String, String> labels, int analysedTotal) {
+            Map<String, String> labels, int analysedTotal,
+            Map<String, PopulationInfo> populationAnnotations, int populationTotal) {
         this.pValues = pValues;
         this.counts = counts;
         this.labels = labels;
         this.analysedTotal = analysedTotal;
+        this.populationAnnotations = populationAnnotations;
+        this.populationTotal = populationTotal;
     }
 
     /**
@@ -68,6 +76,15 @@ public class EnrichmentResults
         return labels;
     }
 
+    /**
+     * Get the count of of each attribute value in the population, e.g. number of total genes
+     * annotated per GO term.
+     * @return labels for each attribute value in the sample
+     */
+    public Map<String, PopulationInfo> getPopulationAnnotations() {
+        return populationAnnotations;
+    }
+
     // this is the number of objects in the bag that had data
     /**
      * Get the number of items in the sample that had an attribute value.  For example if performing
@@ -78,4 +95,18 @@ public class EnrichmentResults
     public int getAnalysedTotal() {
         return analysedTotal;
     }
+
+    // this is the number of objects in the database that had data
+    /**
+     * Get the number of items in the database (or background population) that were annotated.
+     *
+     * NOTE: This is NOT the count of items in the database. We only include genes that have ANY
+     * GO terms because we have a lot of garbage genes.
+     *
+     * @return the number of items in the population that were annotated with ANY value
+     */
+    public int getPopulationTotal() {
+        return populationTotal;
+    }
+
 }

--- a/intermine/web/main/src/org/intermine/web/logic/widget/EnrichmentWidget.java
+++ b/intermine/web/main/src/org/intermine/web/logic/widget/EnrichmentWidget.java
@@ -168,6 +168,7 @@ public class EnrichmentWidget extends Widget
                 size = idArray.length;
             }
             setNotAnalysed(size - results.getAnalysedTotal());
+            setPopulationCount(results.getPopulationTotal());
         } catch (ObjectStoreException e) {
             throw new RuntimeException(e);
         }
@@ -250,12 +251,15 @@ public class EnrichmentWidget extends Widget
             Map<String, BigDecimal> pValues = results.getPValues();
             Map<String, Integer> counts = results.getCounts();
             Map<String, String> labels = results.getLabels();
+            Map<String, PopulationInfo> annotatedPopulationInfo
+                = results.getPopulationAnnotations();
             for (String id : pValues.keySet()) {
                 List<Object> row = new LinkedList<Object>();
                 row.add(id);
                 row.add(labels.get(id));
                 row.add(pValues.get(id).doubleValue());
                 row.add(counts.get(id));
+                row.add(annotatedPopulationInfo.get(id).getSize());
                 exportResults.add(row);
             }
         }

--- a/intermine/web/main/src/org/intermine/web/logic/widget/Widget.java
+++ b/intermine/web/main/src/org/intermine/web/logic/widget/Widget.java
@@ -36,6 +36,7 @@ public abstract class Widget
     protected String ids;
     protected ObjectStore os;
     protected int notAnalysed = 0;
+    protected int poplationCount = 0;
 
     /**
      * The constructor
@@ -64,6 +65,20 @@ public abstract class Widget
      */
     public void setNotAnalysed(int notAnalysed) {
         this.notAnalysed = notAnalysed;
+    }
+
+    /**
+     * @return the number of objects in the database annotated with ANY GO term
+     */
+    public int getPopulationCount() {
+        return poplationCount;
+    }
+
+    /**
+     * @param poplationCount the number of objects in the population
+     */
+    public void setPopulationCount(int poplationCount) {
+        this.poplationCount = poplationCount;
     }
 
     /**

--- a/intermine/web/main/src/org/intermine/webservice/server/widget/EnrichmentJSONProcessor.java
+++ b/intermine/web/main/src/org/intermine/webservice/server/widget/EnrichmentJSONProcessor.java
@@ -40,10 +40,9 @@ public final class EnrichmentJSONProcessor implements WidgetResultProcessor
         backingMap.put("identifier", row.get(0));
         backingMap.put("description", row.get(1));
         backingMap.put("p-value", row.get(2));
-        // Counts (index 3) are not necessary here, as it it trivial to
-        // fetch from the matches array (as result.matches.length)
-        //List<Map<String, Object>> matchesDetail = (List<Map<String, Object>>) row.get(4);
         backingMap.put("matches", row.get(3));
+        // how many in the database were annotated with this GO term
+        backingMap.put("populationAnnotationCount", row.get(4));
         JSONObject jo = new JSONObject(backingMap);
         return new LinkedList<String>(Arrays.asList(jo.toString()));
     }

--- a/intermine/web/main/src/org/intermine/webservice/server/widget/EnrichmentWidgetResultService.java
+++ b/intermine/web/main/src/org/intermine/webservice/server/widget/EnrichmentWidgetResultService.java
@@ -156,6 +156,8 @@ public class EnrichmentWidgetResultService extends WidgetService
                                                + input.getWidgetId() + "\"");
         }
         addOutputInfo("notAnalysed", Integer.toString(widget.getNotAnalysed()));
+        // total number of genes in database annotated with ANY GO term
+        addOutputInfo("populationCount", Integer.toString(widget.getPopulationCount()));
         addOutputPathQuery(widget, widgetConfig);
         addOutputExtraAttribute(input, widget);
 

--- a/intermine/web/main/src/org/intermine/webservice/server/widget/EnrichmentXMLProcessor.java
+++ b/intermine/web/main/src/org/intermine/webservice/server/widget/EnrichmentXMLProcessor.java
@@ -43,7 +43,8 @@ public final class EnrichmentXMLProcessor implements WidgetResultProcessor
             put(Integer.valueOf(0), "identifier");
             put(Integer.valueOf(1), "description");
             put(Integer.valueOf(2), "pValue");
-            put(Integer.valueOf(3), "count"); // Not used for now. May make a return later.
+            put(Integer.valueOf(3), "count");
+            put(Integer.valueOf(4), "populationAnnotationCount");
         }
     };
 


### PR DESCRIPTION
There are four numbers used to calculate enrichment:

```
n
    the number of objects in your list
N
    the number of objects in the reference population, e.g. number of genes anntotated 
with ANY GO term 
k
    the number of objects annotated with this item in your list
M
    the number of objects annotated with item in the reference population 
```
See http://intermine.readthedocs.io/en/latest/embedding/list-widgets/enrichment-widgets/

These numbers are now in the enrichment output:


<table>
<tr>
<td>n
</td>
<td> the number of objects in your list
</td>
<td>the list size
</td>
</tr>


<tr>
<td>N
</td>
<td> the number of objects in the reference population
</td>
<td>`populationCount` attribute in the header
</td>
</tr>

<tr>
<td>k
</td>
<td>the number of objects annotated with this item in your list
</td>
<td>`count` in results, one count per GO term
</td>
</tr>


<tr>
<td>M
</td>
<td> the number of objects annotated with item in the reference population 
</td>
<td>`populationAnnotationCount` in results, one count per GO term
</td>
</tr>
</table>


