### PR TITLE
only look in public schema when counting rows in a table

### DIFF
--- a/intermine/objectstore/main/src/org/intermine/sql/writebatch/BatchWriterPostgresCopyImpl.java
+++ b/intermine/objectstore/main/src/org/intermine/sql/writebatch/BatchWriterPostgresCopyImpl.java
@@ -244,7 +244,8 @@ public class BatchWriterPostgresCopyImpl extends BatchWriterPreparedStatementImp
     @Override
     protected int getTableSize(String name, Connection conn) throws SQLException {
         Statement s = conn.createStatement();
-        ResultSet r = s.executeQuery("SELECT reltuples FROM pg_class WHERE relname = '"
+        ResultSet r = s.executeQuery("SELECT reltuples FROM pg_class c, pg_namespace n WHERE "
+                + "n.oid=c.relnamespace AND n.nspname='public' AND relname = '"
                 + name.toLowerCase() + "'");
         if (r.next()) {
             int returnValue = (int) r.getFloat(1);


### PR DESCRIPTION
Minor issue: I had a mine with a table named gene in a different schema. When counting rows, the query did not restrict to the public schema and I got a build exception.