### PR TITLE
Enables user login tracking in LOGIN_TRACK_TABLE for OAuth2 flow

### DIFF
--- a/intermine/web/main/src/org/intermine/web/struts/oauth2/Callback.java
+++ b/intermine/web/main/src/org/intermine/web/struts/oauth2/Callback.java
@@ -337,6 +337,9 @@ public class Callback extends LoginHandler
             issues = mergeProfiles(currentProfile, profile);
         }
 
+        // track the user login
+        api.getTrackerDelegate().trackLogin(profile.getUsername());
+
         // Removed the mapping process because it's no longer necessary, and also blank strings
         // in the user preferences might be causing trouble.
         // TODO: Remove related dead code


### PR DESCRIPTION
Simple fix to the OAuth2 Callback controller to enable tracking of user logins in the LOGIN_TRACK_TABLE (`logintrack` table in the userprofile DB).

Thanks to @JoeCarlson for his pointers regarding this issue (on the IM Discord chat)!