### PR TITLE
Don't store term if name is missing, but keep on

### DIFF
--- a/bio/core/main/src/org/intermine/bio/ontology/OboParser.java
+++ b/bio/core/main/src/org/intermine/bio/ontology/OboParser.java
@@ -248,12 +248,10 @@ public class OboParser
             List<?> names = (List<?>) tvs.get("name");
             if (names != null && !names.isEmpty()) {
                 name = (String) names.get(0);
-            } else {
-                //throw new BuildException("Ontology term did not have a name:" + id);
+                boolean isTransitive = isTrue(tvs, "is_transitive");
+                oboType = new OboTypeDefinition(id, name, isTransitive);
+                types.put(oboType.getId() , oboType);
             }
-            boolean isTransitive = isTrue(tvs, "is_transitive");
-            oboType = new OboTypeDefinition(id, name, isTransitive);
-            types.put(oboType.getId() , oboType);
         }
 
         // Just build all the OboTerms disconnected
@@ -264,12 +262,10 @@ public class OboParser
             List<?> names = (List<?>) tvs.get("name");
             if (names != null && !names.isEmpty()) {
                 name = (String) names.get(0);
-            } else {
-                throw new BuildException("Ontology term did not have a name:" + id);
+                OboTerm term = new OboTerm(id, name);
+                term.setObsolete(isTrue(tvs, "is_obsolete"));
+                terms.put(term.getId(), term);
             }
-            OboTerm term = new OboTerm(id, name);
-            term.setObsolete(isTrue(tvs, "is_obsolete"));
-            terms.put(term.getId(), term);
         }
 
         // Now connect them all together

--- a/bio/core/main/src/org/intermine/bio/ontology/OboParser.java
+++ b/bio/core/main/src/org/intermine/bio/ontology/OboParser.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.collections.map.MultiValueMap;
 import org.apache.log4j.Logger;
-import org.apache.tools.ant.BuildException;
 import org.obo.dataadapter.OBOAdapter;
 import org.obo.dataadapter.OBOFileAdapter;
 import org.obo.dataadapter.OBOSerializationEngine;


### PR DESCRIPTION
The minor comment-out that was recently done to deal with missing names didn't cut it; the second set of code didn't have it commented out, so files like to.obo (Trait Ontology) still crashed. I think storing a term without a name is a Bad Idea, so I've simply changed the code to require that name exist to store a term, but not bail out if a term is missing the name. This successfully loads to.obo (after removing some include URLs at the top that no longer work correctly).