### PR TITLE
When building objectstore, use the 9.4.1212.jre7 as used by the pre-g…

### DIFF
--- a/intermine/objectstore/build.gradle
+++ b/intermine/objectstore/build.gradle
@@ -30,7 +30,7 @@ configurations {
 
 dependencies {
     compile project(':intermine-model')
-    compile group: 'org.postgresql', name: 'postgresql', version: '9.4.1212'
+    compile group: 'org.postgresql', name: 'postgresql', version: '9.4.1212.jre7'
     compile group: 'commons-io', name: 'commons-io', version: '1.2'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.6.1'
     compile group: 'com.zaxxer', name: 'HikariCP-java6', version: '2.3.8'


### PR DESCRIPTION
…radle build, not yet the jre8 9.4.1212

This is because there will be issues trying to use the jre8 jar with a jre7 jvm, which is still intermine's minimum version at this point

## Details

*Summary of pull request, including references to relevant tickets (if applicable).*

## Testing

*Besides running unit tests, how can the reviewer test your feature / bug fix? Are there edge cases to be aware of?*

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
