### PR TITLE
Update URLGenerator.java to handle HTTPS sites

### DIFF
--- a/intermine/web/main/src/org/intermine/web/util/URLGenerator.java
+++ b/intermine/web/main/src/org/intermine/web/util/URLGenerator.java
@@ -62,13 +62,13 @@ public class URLGenerator
             return getCurrentURL(request, contextPath);
         }
 
-        if (request.getServerPort()!=80 && request.getServerPort()!=443) {
+        if (request.getServerPort() != 80 && request.getServerPort() != 443) {
             baseUrl += ":" + request.getServerPort();
         }
         String path = webProperties.getProperty("webapp.path");
         URL url = null;
         try {
-	    url = new URL(baseUrl+path);
+	    url = new URL(baseUrl + path);
         } catch (MalformedURLException e) {
             // whoops somethings gone terribly wrong. Use the URL
             return getCurrentURL(request, contextPath);
@@ -80,7 +80,7 @@ public class URLGenerator
     // SH 2/20/18 fix to handle plain HTTPS hosts as well
     private String getCurrentURL(HttpServletRequest request, String contextPath) {
         String port = "";
-        if (request.getServerPort()!=80 && request.getServerPort()!=443) {
+        if (request.getServerPort() != 80 && request.getServerPort() != 443) {
             port = ":" + request.getServerPort();
         }
         String ret = request.getScheme() + "://" + request.getServerName() + port;

--- a/intermine/web/main/src/org/intermine/web/util/URLGenerator.java
+++ b/intermine/web/main/src/org/intermine/web/util/URLGenerator.java
@@ -68,7 +68,7 @@ public class URLGenerator
         String path = webProperties.getProperty("webapp.path");
         URL url = null;
         try {
-	    url = new URL(baseUrl + path);
+            url = new URL(baseUrl + path);
         } catch (MalformedURLException e) {
             // whoops somethings gone terribly wrong. Use the URL
             return getCurrentURL(request, contextPath);

--- a/intermine/web/main/src/org/intermine/web/util/URLGenerator.java
+++ b/intermine/web/main/src/org/intermine/web/util/URLGenerator.java
@@ -53,6 +53,7 @@ public class URLGenerator
         return generateURL(request, request.getContextPath());
     }
 
+    // SH 2/20/18 fix to handle plain HTTPS hosts as well and remove the extra slash
     private String generateURL(HttpServletRequest request, String contextPath) {
         final Properties webProperties = InterMineContext.getWebProperties();
         String baseUrl = webProperties.getProperty("webapp.baseurl");
@@ -61,13 +62,13 @@ public class URLGenerator
             return getCurrentURL(request, contextPath);
         }
 
-        if (request.getServerPort() != 80) {
+        if (request.getServerPort()!=80 && request.getServerPort()!=443) {
             baseUrl += ":" + request.getServerPort();
         }
         String path = webProperties.getProperty("webapp.path");
         URL url = null;
         try {
-            url = new URL(baseUrl + "/" + path);
+	    url = new URL(baseUrl+path);
         } catch (MalformedURLException e) {
             // whoops somethings gone terribly wrong. Use the URL
             return getCurrentURL(request, contextPath);
@@ -76,9 +77,10 @@ public class URLGenerator
     }
 
     // only use if they haven't set up baseURL
+    // SH 2/20/18 fix to handle plain HTTPS hosts as well
     private String getCurrentURL(HttpServletRequest request, String contextPath) {
         String port = "";
-        if (request.getServerPort() != 80) {
+        if (request.getServerPort()!=80 && request.getServerPort()!=443) {
             port = ":" + request.getServerPort();
         }
         String ret = request.getScheme() + "://" + request.getServerName() + port;


### PR DESCRIPTION
The port handling of generateURL and getCurrentURL broke the permaLink on HTTPS sites. This fixes that problem. Tested on live BeanMine.

## Details

*Summary of pull request, including references to relevant tickets (if applicable).*

## Testing

*Besides running unit tests, how can the reviewer test your feature / bug fix? Are there edge cases to be aware of?*

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
