### PR TITLE
Update other-mines-links.js

### DIFF
--- a/intermine/webapp/main/resources/webapp/js/other-mines-links.js
+++ b/intermine/webapp/main/resources/webapp/js/other-mines-links.js
@@ -79,11 +79,11 @@ var OtherMines = (function ($, _, AjaxServices) {
       {name: 'class', value: obj.type},
       {name: 'origin', value: request.origin}
     ];
-    if (group.domain === request.domain) {
-      params.push({
-        name: OtherMines.DOMAIN_PARAMETER_NAME, value: request.domain
-      });
-    }
+    // if (group.domain === request.domain) {
+    //   params.push({
+    //     name: OtherMines.DOMAIN_PARAMETER_NAME, value: request.domain
+    //   });
+    // }
     var data = {
       name: (obj.name || obj.identifier),
       mineLink: mine.url + '/portal.do?' + queryString(params)


### PR DESCRIPTION
I've commented out the DOMAIN_PARAMETER_NAME chunk because it was breaking the links to gene pages when present. For example, on LegumeMine, looking at a Cowpea gene, a homolog was listed on CowpeaMine, call it gene A; but when one clicked that link (which had the correct gene ID), CowpeaMine loaded the report page for a DIFFERENT gene. I say that's a bug. This fixes it.

## Details

*Summary of pull request, including references to relevant tickets (if applicable).*

## Testing

*Besides running unit tests, how can the reviewer test your feature / bug fix? Are there edge cases to be aware of?*

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [x] Passing unit test for new or updated code (if applicable)
- [x] Passes all tests – according to Travis
- [x] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [x] Checkstyle
