### PR TITLE
Remove "node" element from pathquery XML parsing

### DIFF
--- a/bio/sources/uniprot/main/src/org/intermine/bio/dataconversion/UniprotConverter.java
+++ b/bio/sources/uniprot/main/src/org/intermine/bio/dataconversion/UniprotConverter.java
@@ -449,6 +449,8 @@ public class UniprotConverter extends BioDirectoryConverter
                 String type = getAttrValue(attrs, "type");
                 String id = getAttrValue(attrs, "id");
                 disease.setIdentifier(type + ":" + id);
+            } else if ("scope".equals(qName) && "reference".equals(previousQName)) {
+                attName = "scope";
             } else if ("dbreference".equals(qName) || "comment".equals(qName)
                     || "isoform".equals(qName) || "gene".equals(qName)) {
                 // set temporary holder variables to null
@@ -576,6 +578,12 @@ public class UniprotConverter extends BioDirectoryConverter
             } else if ("comment".equals(qName)) {
                 // on closing a comment, make sure the disease holder is empty
                 disease = null;
+            } else if ("scope".equals(qName)) {
+                String scope = attValue.toString();
+                // the publication we just processed was RETRACTED, so we don't want to load
+                if (scope.contains("RETRACTED")) {
+                    entry.deleteLastPub();
+                }
             } else if ("name".equals(qName) && "isoform".equals(previousQName)) {
                 if (!attValue.toString().matches("[0-9]+")) {
                     entry.addIsoformSynonym(attValue.toString());

--- a/bio/sources/uniprot/main/src/org/intermine/bio/dataconversion/UniprotEntry.java
+++ b/bio/sources/uniprot/main/src/org/intermine/bio/dataconversion/UniprotEntry.java
@@ -255,6 +255,15 @@ public class UniprotEntry
     }
 
     /**
+     * This publication has been retracted. We don't know about retractions until after we've
+     * parsed the pubmed, so we have to do it this dumb way.
+     */
+    public void deleteLastPub() {
+        List<String> pubs = collections.get("pubs");
+        pubs.remove(pubs.size() - 1);
+    }
+
+    /**
      * @return list of ecNumbers for this protein
      */
     public List<String> getECNumbers() {

--- a/bio/sources/uniprot/test/resources/7227_testing_sprot.xml
+++ b/bio/sources/uniprot/test/resources/7227_testing_sprot.xml
@@ -46,6 +46,7 @@
     <dbReference type="PubMed" id="1111111" key="9"/>
   </citation>
 </reference>
+<reference key="10"><citation type="journal article" date="2002" name="Nature" volume="419" first="857" last="862"><title>Histone methylation by the Drosophila epigenetic transcriptional regulator Ash1.</title><authorList><person name="Beisel C."/><person name="Imhof A."/><person name="Greene J."/><person name="Kremmer E."/><person name="Sauer F."/></authorList><dbReference type="PubMed" id="12397363"/><dbReference type="DOI" id="10.1038/nature01126"/></citation><scope>RETRACTED PAPER</scope></reference>
 <comment type="subcellular location">
   <text evidence="EC1">Nucleus.</text>
 </comment>

--- a/bio/sources/uniprot/test/resources/UniprotConverterTest_tgt.xml
+++ b/bio/sources/uniprot/test/resources/UniprotConverterTest_tgt.xml
@@ -3,7 +3,7 @@
 <attribute name="identifier" value="GO:0000003"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="12_6" class="CrossReference">
+<item id="12_7" class="CrossReference">
 <attribute name="identifier" value="NP_523670.2"/>
 <reference name="source" ref_id="1_2"/>
 <reference name="subject" ref_id="7_4"/>
@@ -11,24 +11,14 @@
 <item id="3_2" class="Publication">
 <attribute name="pubMedId" value="1111111"/>
 </item>
-<item id="19_8" class="Synonym">
-<attribute name="value" value="alternativeName - full"/>
-<reference name="subject" ref_id="7_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
-<item id="19_11" class="Synonym">
-<attribute name="value" value="Soluble"/>
-<reference name="subject" ref_id="7_3"/>
+<item id="19_17" class="Synonym">
+<attribute name="value" value="Somatic-2"/>
+<reference name="subject" ref_id="7_4"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="19_3" class="Synonym">
 <attribute name="value" value="alternativeName - short"/>
 <reference name="subject" ref_id="7_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
-<item id="19_12" class="Synonym">
-<attribute name="value" value="EVE_DROME-2"/>
-<reference name="subject" ref_id="7_3"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="14_1" class="GOEvidenceCode">
@@ -39,34 +29,39 @@
 <reference name="source" ref_id="1_2"/>
 <reference name="subject" ref_id="7_2"/>
 </item>
+<item id="12_3" class="CrossReference">
+<attribute name="identifier" value="P22966-1"/>
+<reference name="source" ref_id="1_1"/>
+<reference name="subject" ref_id="7_2"/>
+</item>
 <item id="4_1" class="Comment">
 <attribute name="description" value="Nucleus."/>
 <attribute name="type" value="subcellular location"/>
 <collection name="publications"><reference ref_id="3_1"/></collection>
 </item>
-<item id="0_2" class="Ontology">
-<attribute name="name" value="UniProtKeyword"/>
-</item>
-<item id="19_6" class="Synonym">
-<attribute name="value" value="EVE_DROME-4"/>
+<item id="19_10" class="Synonym">
+<attribute name="value" value="shortname"/>
 <reference name="subject" ref_id="7_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="0_2" class="Ontology">
+<attribute name="name" value="UniProtKeyword"/>
 </item>
 <item id="0_1" class="Ontology">
 <attribute name="name" value="Sequence Ontology"/>
 <attribute name="url" value="http://www.sequenceontology.org"/>
 </item>
-<item id="12_7" class="CrossReference">
-<attribute name="identifier" value="P22966-1"/>
+<item id="19_11" class="Synonym">
+<attribute name="value" value="alternativeName - full"/>
+<reference name="subject" ref_id="7_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="12_9" class="CrossReference">
+<attribute name="identifier" value="Soluble"/>
 <reference name="source" ref_id="1_1"/>
 <reference name="subject" ref_id="7_4"/>
 </item>
-<item id="19_17" class="Synonym">
-<attribute name="value" value="Testis-specific"/>
-<reference name="subject" ref_id="7_4"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
-<item id="7_4" class="Protein">
+<item id="7_2" class="Protein">
 <attribute name="isFragment" value="false"/>
 <attribute name="isUniprotCanonical" value="false"/>
 <attribute name="name" value="eve's name"/>
@@ -105,20 +100,15 @@
 <collection name="goAnnotation"><reference ref_id="16_1"/><reference ref_id="16_2"/><reference ref_id="16_3"/></collection>
 <collection name="publications"><reference ref_id="3_1"/><reference ref_id="3_2"/></collection>
 </item>
-<item id="19_16" class="Synonym">
-<attribute name="value" value="P22966-1"/>
-<reference name="subject" ref_id="7_4"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
 <item id="19_20" class="Synonym">
 <attribute name="value" value="shortname"/>
 <reference name="subject" ref_id="7_4"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="12_5" class="CrossReference">
-<attribute name="identifier" value="Soluble"/>
+<item id="12_8" class="CrossReference">
+<attribute name="identifier" value="Somatic-2"/>
 <reference name="source" ref_id="1_1"/>
-<reference name="subject" ref_id="7_3"/>
+<reference name="subject" ref_id="7_4"/>
 </item>
 <item id="3_1" class="Publication">
 <attribute name="pubMedId" value="222222"/>
@@ -144,6 +134,11 @@
 <collection name="keywords"><reference ref_id="5_1"/><reference ref_id="5_2"/><reference ref_id="5_3"/></collection>
 <collection name="publications"><reference ref_id="3_1"/><reference ref_id="3_2"/></collection>
 </item>
+<item id="19_12" class="Synonym">
+<attribute name="value" value="alternativeName - short"/>
+<reference name="subject" ref_id="7_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
 <item id="8_3" class="ECNumber">
 <attribute name="identifier" value="1.1.1.-"/>
 </item>
@@ -152,6 +147,11 @@
 <reference name="subject" ref_id="13_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 <collection name="evidence"><reference ref_id="15_3"/></collection>
+</item>
+<item id="19_8" class="Synonym">
+<attribute name="value" value="ACE-T"/>
+<reference name="subject" ref_id="7_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="19_5" class="Synonym">
 <attribute name="value" value="Somatic-1"/>
@@ -165,16 +165,6 @@
 <item id="4_5" class="Comment">
 <attribute name="description" value="MIM:137800; Glioma 1; GLM1; Gliomas are benign or malignant central nervous system neoplasms derived from glial cells. They comprise astrocytomas and glioblastoma multiforme that are derived from astrocytes, oligodendrogliomas derived from oligodendrocytes and ependymomas derived from ependymocytes. Disease susceptibility may be associated with variations affecting the gene represented in this entry. Polymorphic PPARG alleles have been found to be significantly over-represented among a cohort of American patients with sporadic glioblastoma multiforme suggesting a possible contribution to disease susceptibility."/>
 <attribute name="type" value="disease"/>
-</item>
-<item id="19_7" class="Synonym">
-<attribute name="value" value="shortname"/>
-<reference name="subject" ref_id="7_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
-<item id="19_19" class="Synonym">
-<attribute name="value" value="EVE_DROME-3"/>
-<reference name="subject" ref_id="7_4"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="1_1" class="DataSource">
 <attribute name="name" value="UniProt"/>
@@ -192,15 +182,25 @@
 <collection name="goAnnotation"><reference ref_id="16_4"/><reference ref_id="16_5"/><reference ref_id="16_6"/></collection>
 <collection name="publications"><reference ref_id="3_1"/><reference ref_id="3_2"/></collection>
 </item>
-<item id="19_9" class="Synonym">
-<attribute name="value" value="alternativeName - short"/>
-<reference name="subject" ref_id="7_2"/>
+<item id="19_19" class="Synonym">
+<attribute name="value" value="EVE_DROME-2"/>
+<reference name="subject" ref_id="7_4"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="19_22" class="Synonym">
 <attribute name="value" value="alternativeName - short"/>
 <reference name="subject" ref_id="7_4"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="19_13" class="Synonym">
+<attribute name="value" value="EVE_DROME-4"/>
+<reference name="subject" ref_id="7_3"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="4_3" class="Comment">
+<attribute name="description" value="Contains 1homeobox DNA-binding domain."/>
+<attribute name="type" value="similarity"/>
+<collection name="publications"><reference ref_id="3_1"/><reference ref_id="3_2"/></collection>
 </item>
 <item id="12_1" class="CrossReference">
 <attribute name="identifier" value="NP_523670.2"/>
@@ -214,11 +214,6 @@
 <attribute name="length" value="376"/>
 <attribute name="md5checksum" value="010f63e81bfbde1299baffea3f5801e7"/>
 <attribute name="residues" value="MHGYRTYNMESHHAHHDASPVDQKPLVVDLLATQYGKPQTPPPSPNECLSSPDNSLNGSRGSEIPADPSVRRYRTAFTRDQLGRLEKEFYKENYVSRPRRCELAAQLNLPESTIKVWFQNRRMKDKRQRIAVAWPYAAVYSDPAFAASILQAAANSVGMPYPPYAPAAAAAAAAAAAVATNPMMATGMPPMGMPQMPTMQMPGHSGHAGHPSPYGQYRYTPYHIPARPAPPHPAGPHMHHPHMMGSSATGSSYSAGAAGLLGALPSATCYTGLGVGVPKTQTPPLDLQSSSSPHSSTLSLSPVGSDHAKVFDRSPVAQSAPSVPAPAPLTTTSPLPAPGLLMPSAKRPASDMSPPPTTTVIAEPKPKLFKPYKTEA"/>
-</item>
-<item id="19_14" class="Synonym">
-<attribute name="value" value="alternativeName - full"/>
-<reference name="subject" ref_id="7_3"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="19_1" class="Synonym">
 <attribute name="value" value="shortname"/>
@@ -245,6 +240,11 @@
 <item id="14_2" class="GOEvidenceCode">
 <attribute name="code" value="IMP"/>
 </item>
+<item id="19_15" class="Synonym">
+<attribute name="value" value="alternativeName - full"/>
+<reference name="subject" ref_id="7_3"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
 <item id="2_1" class="DataSet">
 <attribute name="name" value="Swiss-Prot data set"/>
 <reference name="dataSource" ref_id="1_1"/>
@@ -252,10 +252,7 @@
 <item id="10_1" class="Organism">
 <attribute name="taxonId" value="7227"/>
 </item>
-<item id="15_2" class="GOEvidence">
-<reference name="code" ref_id="14_2"/>
-</item>
-<item id="7_2" class="Protein">
+<item id="7_3" class="Protein">
 <attribute name="isFragment" value="false"/>
 <attribute name="isUniprotCanonical" value="false"/>
 <attribute name="name" value="eve's name"/>
@@ -272,6 +269,14 @@
 <collection name="keywords"><reference ref_id="5_1"/><reference ref_id="5_2"/><reference ref_id="5_3"/></collection>
 <collection name="publications"><reference ref_id="3_1"/><reference ref_id="3_2"/></collection>
 </item>
+<item id="15_2" class="GOEvidence">
+<reference name="code" ref_id="14_2"/>
+</item>
+<item id="12_4" class="CrossReference">
+<attribute name="identifier" value="Testis-specific"/>
+<reference name="source" ref_id="1_1"/>
+<reference name="subject" ref_id="7_2"/>
+</item>
 <item id="15_5" class="GOEvidence">
 <reference name="code" ref_id="14_2"/>
 </item>
@@ -286,22 +291,17 @@
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="19_18" class="Synonym">
-<attribute name="value" value="ACE-T"/>
+<attribute name="value" value="Soluble"/>
 <reference name="subject" ref_id="7_4"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="15_3" class="GOEvidence">
 <reference name="code" ref_id="14_1"/>
 </item>
-<item id="19_10" class="Synonym">
-<attribute name="value" value="Somatic-2"/>
-<reference name="subject" ref_id="7_3"/>
+<item id="19_6" class="Synonym">
+<attribute name="value" value="P22966-1"/>
+<reference name="subject" ref_id="7_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
-<item id="12_8" class="CrossReference">
-<attribute name="identifier" value="Testis-specific"/>
-<reference name="source" ref_id="1_1"/>
-<reference name="subject" ref_id="7_4"/>
 </item>
 <item id="15_4" class="GOEvidence">
 <reference name="code" ref_id="14_1"/>
@@ -309,6 +309,14 @@
 <item id="17_1" class="GOTerm">
 <attribute name="identifier" value="GO:0000001"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="19_9" class="Synonym">
+<attribute name="value" value="EVE_DROME-3"/>
+<reference name="subject" ref_id="7_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_3" class="Publication">
+<attribute name="pubMedId" value="12397363"/>
 </item>
 <item id="5_4" class="OntologyTerm">
 <attribute name="name" value="helix"/>
@@ -318,12 +326,7 @@
 <item id="15_6" class="GOEvidence">
 <reference name="code" ref_id="14_1"/>
 </item>
-<item id="19_13" class="Synonym">
-<attribute name="value" value="shortname"/>
-<reference name="subject" ref_id="7_3"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
-<item id="19_15" class="Synonym">
+<item id="19_16" class="Synonym">
 <attribute name="value" value="alternativeName - short"/>
 <reference name="subject" ref_id="7_3"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
@@ -334,6 +337,11 @@
 <attribute name="type" value="signal peptide"/>
 <reference name="feature" ref_id="5_6"/>
 <reference name="protein" ref_id="7_1"/>
+</item>
+<item id="19_14" class="Synonym">
+<attribute name="value" value="shortname"/>
+<reference name="subject" ref_id="7_3"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="1_2" class="DataSource">
 <attribute name="name" value="RefSeq"/>
@@ -356,27 +364,15 @@
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 <collection name="evidence"><reference ref_id="15_5"/></collection>
 </item>
-<item id="12_9" class="CrossReference">
-<attribute name="identifier" value="ACE-T"/>
-<reference name="source" ref_id="1_1"/>
-<reference name="subject" ref_id="7_4"/>
-</item>
 <item id="5_6" class="OntologyTerm">
 <attribute name="name" value="signal peptide"/>
 <reference name="ontology" ref_id="0_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_3" class="Comment">
-<attribute name="description" value="Contains 1 homeobox DNA-binding domain."/>
-<attribute name="type" value="similarity"/>
-<collection name="publications"><reference ref_id="3_1"/><reference ref_id="3_2"/></collection>
+<item id="8_2" class="ECNumber">
+<attribute name="identifier" value="1.1.1.1"/>
 </item>
-<item id="12_3" class="CrossReference">
-<attribute name="identifier" value="NP_523670.2"/>
-<reference name="source" ref_id="1_2"/>
-<reference name="subject" ref_id="7_3"/>
-</item>
-<item id="7_3" class="Protein">
+<item id="7_4" class="Protein">
 <attribute name="isFragment" value="false"/>
 <attribute name="isUniprotCanonical" value="false"/>
 <attribute name="name" value="eve's name"/>
@@ -392,9 +388,6 @@
 <collection name="genes"><reference ref_id="13_1"/><reference ref_id="13_2"/></collection>
 <collection name="keywords"><reference ref_id="5_1"/><reference ref_id="5_2"/><reference ref_id="5_3"/></collection>
 <collection name="publications"><reference ref_id="3_1"/><reference ref_id="3_2"/></collection>
-</item>
-<item id="8_2" class="ECNumber">
-<attribute name="identifier" value="1.1.1.1"/>
 </item>
 <item id="16_4" class="GOAnnotation">
 <reference name="ontologyTerm" ref_id="17_1"/>
@@ -421,13 +414,23 @@
 <reference name="ontology" ref_id="0_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
+<item id="12_5" class="CrossReference">
+<attribute name="identifier" value="ACE-T"/>
+<reference name="source" ref_id="1_1"/>
+<reference name="subject" ref_id="7_2"/>
+</item>
+<item id="19_7" class="Synonym">
+<attribute name="value" value="Testis-specific"/>
+<reference name="subject" ref_id="7_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
 <item id="11_1" class="Component">
 <attribute name="name" value="full component name"/>
 <reference name="protein" ref_id="7_1"/>
 </item>
-<item id="12_4" class="CrossReference">
-<attribute name="identifier" value="Somatic-2"/>
-<reference name="source" ref_id="1_1"/>
+<item id="12_6" class="CrossReference">
+<attribute name="identifier" value="NP_523670.2"/>
+<reference name="source" ref_id="1_2"/>
 <reference name="subject" ref_id="7_3"/>
 </item>
 <item id="6_3" class="UniProtFeature">

--- a/intermine/pathquery/main/src/org/intermine/pathquery/PathQueryHandler.java
+++ b/intermine/pathquery/main/src/org/intermine/pathquery/PathQueryHandler.java
@@ -162,26 +162,6 @@ public class PathQueryHandler extends DefaultHandler
             }
             constraintLogic = attrs.getValue("constraintLogic");
             questionableSubclasses = new ArrayList<PathConstraintSubclass>();
-        } else if ("node".equals(qName)) {
-            // There's a node tag, so all constraints inside must inherit this
-            // path. Set it in a
-            // variable, and reset the variable to null when we see the end tag.
-
-            currentNodePath = attrs.getValue("path");
-            if (currentNodePath.contains(":")) {
-                setOuterJoins(query, currentNodePath);
-                currentNodePath = currentNodePath.replace(':', '.');
-            }
-            String type = attrs.getValue("type");
-            if ((type != null)
-                    && (!ATTRIBUTE_TYPES.contains(type))
-                    && (currentNodePath.contains(".") || currentNodePath
-                            .contains(":"))) {
-                PathConstraintSubclass subclass = new PathConstraintSubclass(
-                        currentNodePath, type);
-                query.addConstraint(subclass);
-                questionableSubclasses.add(subclass);
-            }
         } else if ("constraint".equals(qName)) {
             String path = attrs.getValue("path");
             if (currentNodePath != null) {
@@ -414,8 +394,6 @@ public class PathQueryHandler extends DefaultHandler
                 }
             }
             queries.put(queryName, query);
-        } else if ("node".equals(qName)) {
-            currentNodePath = null;
         } else if ("constraint".equals(qName) && (constraintPath != null)) {
             PathConstraint constraint = processConstraint(query,
                     constraintPath, constraintAttributes, constraintValues);

--- a/intermine/webapp/main/resources/webapp/WEB-INF/web.xml
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/web.xml
@@ -2908,7 +2908,7 @@ The different token types are:
       <servlet-name>ws-data</servlet-name>
       <url-pattern>/service/data/*</url-pattern>
       <metadata>
-          <name>Simple Data Service</name>
+          <name>JBrowse Simple Data Service</name>
           <minVersion>16</minVersion>
           <method type="GET" authenticationRequired="false" slug="/:type">
               <summary>Get Data about Objects of the Given Type</summary>


### PR DESCRIPTION
I removed node from the XML parsing. I looked in the main query, and it's not parsed there at all (that I could see).

"node" isn't generated as an XML element anymore, nor is it used in JSON. We included this in the list of things that were being phased out as well. 