### PR TITLE
Add publication-fix

### DIFF
--- a/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
+++ b/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
@@ -64,6 +64,10 @@ import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.OperationStatus;
 import com.sleepycat.je.Transaction;
 
+import java.io.DataOutputStream;
+import java.net.HttpURLConnection;
+import javax.net.ssl.HttpsURLConnection;
+
 /**
  * Class to fill in all publication information from pubmed
  * @author Mark Woodbridge
@@ -81,7 +85,7 @@ public class EntrezPublicationsRetriever
     protected static final String ESUMMARY_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/"
             + "eutils/esummary.fcgi?tool=flymine&db=pubmed&id=";
     // number of records to retrieve per request
-    protected static final int BATCH_SIZE = 400;
+    protected static final int BATCH_SIZE = 500;
     // number of times to try the same batch from the server
     private static final int MAX_TRIES = 5;
     private String osAlias = null, outputFile = null;
@@ -356,12 +360,37 @@ public class EntrezPublicationsRetriever
      * @throws Exception if an error occurs
      */
     protected Reader getReader(Set<Integer> ids) throws Exception {
-        String urlString = ESUMMARY_URL + StringUtil.join(ids, ",");
-        if (loadFullRecord) {
-            urlString = EFETCH_URL + StringUtil.join(ids, ",");
-        }
-        System.err .println("retrieving: " + urlString);
-        return new BufferedReader(new InputStreamReader(new URL(urlString).openStream()));
+
+		/**
+		 * Fix - Use HTTP POST instead of HTTP GET method for uploading
+		 * Pubmed Ids
+		 * Author: Norbert Auer
+		 * e-mail: norbert.auer@boku.ac.at
+		 */
+		String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
+		URL obj = new URL(url);
+		HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
+
+		//add reuqest header to POST
+		con.setRequestMethod("POST");
+		//con.setRequestProperty("User-Agent", USER_AGENT);
+		con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
+
+		String urlParameters = "tool=flymine&db=pubmed&rettype=abstract&retmode=xml&id=" + StringUtil.join(ids, ",");
+
+		// Send post request
+		con.setDoOutput(true);
+		DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+		wr.writeBytes(urlParameters);
+		wr.flush();
+		wr.close();
+
+		int responseCode = con.getResponseCode();
+		//System.out.println("\nSending 'POST' request to URL : " + url);
+		//System.out.println("Post parameters : " + urlParameters);
+		//System.out.println("Response Code : " + responseCode);
+
+		return new BufferedReader(new InputStreamReader(con.getInputStream()));
     }
 
     private Set<Item> mapToItems(ItemFactory factory, Map map) {

--- a/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
+++ b/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
@@ -65,7 +65,6 @@ import com.sleepycat.je.OperationStatus;
 import com.sleepycat.je.Transaction;
 
 import java.io.DataOutputStream;
-import java.net.HttpURLConnection;
 import javax.net.ssl.HttpsURLConnection;
 
 /**
@@ -361,36 +360,33 @@ public class EntrezPublicationsRetriever
      */
     protected Reader getReader(Set<Integer> ids) throws Exception {
 
-		/**
-		 * Fix - Use HTTP POST instead of HTTP GET method for uploading
-		 * Pubmed Ids
-		 * Author: Norbert Auer
-		 * e-mail: norbert.auer@boku.ac.at
-		 */
-		String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
-		URL obj = new URL(url);
-		HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
+    /**
+     * Fix - Use HTTP POST instead of HTTP GET method for uploading
+     * Pubmed Ids
+     * Author: Norbert Auer
+     * e-mail: norbert.auer@boku.ac.at
+     */
+     String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
+     URL obj = new URL(url);
+     HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
 
-		//add reuqest header to POST
-		con.setRequestMethod("POST");
-		//con.setRequestProperty("User-Agent", USER_AGENT);
-		con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
+     // add reuqest header to POST
+     con.setRequestMethod("POST");
+     //con.setRequestProperty("User-Agent", USER_AGENT);
+     con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
 
-		String urlParameters = "tool=flymine&db=pubmed&rettype=abstract&retmode=xml&id=" + StringUtil.join(ids, ",");
+     String urlParameters = "tool=flymine&db=pubmed&rettype=abstract&retmode=xml&id=" + StringUtil.join(ids, ",");
 
-		// Send post request
-		con.setDoOutput(true);
-		DataOutputStream wr = new DataOutputStream(con.getOutputStream());
-		wr.writeBytes(urlParameters);
-		wr.flush();
-		wr.close();
+     // Send post request
+     con.setDoOutput(true);
+     DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+     wr.writeBytes(urlParameters);
+     wr.flush();
+     wr.close();
 
-		int responseCode = con.getResponseCode();
-		//System.out.println("\nSending 'POST' request to URL : " + url);
-		//System.out.println("Post parameters : " + urlParameters);
-		//System.out.println("Response Code : " + responseCode);
+     int responseCode = con.getResponseCode();
 
-		return new BufferedReader(new InputStreamReader(con.getInputStream()));
+     return new BufferedReader(new InputStreamReader(con.getInputStream()));
     }
 
     private Set<Item> mapToItems(ItemFactory factory, Map map) {

--- a/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
+++ b/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
@@ -359,34 +359,34 @@ public class EntrezPublicationsRetriever
      * @throws Exception if an error occurs
      */
     protected Reader getReader(Set<Integer> ids) throws Exception {
+        /**
+         * Fix - Use HTTP POST instead of HTTP GET method for uploading
+         * Pubmed Ids
+         * Author: Norbert Auer
+         * e-mail: norbert.auer@boku.ac.at
+         */
+         String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
+         URL obj = new URL(url);
+         HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
 
-    /**
-     * Fix - Use HTTP POST instead of HTTP GET method for uploading
-     * Pubmed Ids
-     * Author: Norbert Auer
-     * e-mail: norbert.auer@boku.ac.at
-     */
-     String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
-     URL obj = new URL(url);
-     HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
+         // add reuqest header to POST
+         con.setRequestMethod("POST");
 
-     // add reuqest header to POST
-     con.setRequestMethod("POST");
-     //con.setRequestProperty("User-Agent", USER_AGENT);
-     con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
+         // con.setRequestProperty("User-Agent", USER_AGENT);
+         con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
 
-     String urlParameters = "tool=flymine&db=pubmed&rettype=abstract&retmode=xml&id=" + StringUtil.join(ids, ",");
+         String urlParameters = "tool=flymine&db=pubmed&rettype=abstract&retmode=xml&id=" + StringUtil.join(ids, ",");
 
-     // Send post request
-     con.setDoOutput(true);
-     DataOutputStream wr = new DataOutputStream(con.getOutputStream());
-     wr.writeBytes(urlParameters);
-     wr.flush();
-     wr.close();
+         // Send post request
+         con.setDoOutput(true);
+         DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+         wr.writeBytes(urlParameters);
+         wr.flush();
+         wr.close();
 
-     int responseCode = con.getResponseCode();
+         int responseCode = con.getResponseCode();
 
-     return new BufferedReader(new InputStreamReader(con.getInputStream()));
+         return new BufferedReader(new InputStreamReader(con.getInputStream()));
     }
 
     private Set<Item> mapToItems(ItemFactory factory, Map map) {

--- a/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
+++ b/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
@@ -78,11 +78,10 @@ public class EntrezPublicationsRetriever
     // full record (new)
     // rettype=abstract or just leave it out
     protected static final String EFETCH_URL =
-        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?tool=flymine&db=pubmed"
-        + "&rettype=abstract&retmode=xml&id=";
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
     // summary
     protected static final String ESUMMARY_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/"
-            + "eutils/esummary.fcgi?tool=flymine&db=pubmed&id=";
+            + "eutils/esummary.fcgi";
     // number of records to retrieve per request
     protected static final int BATCH_SIZE = 500;
     // number of times to try the same batch from the server
@@ -365,17 +364,21 @@ public class EntrezPublicationsRetriever
          * Author: Norbert Auer
          * e-mail: norbert.auer@boku.ac.at
          */
-        String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
-        URL obj = new URL(url);
+
+        String urlString = ESUMMARY_URL;
+        if (loadFullRecord) {
+            urlString = EFETCH_URL;
+        }
+        URL obj = new URL(urlString);
         HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
 
-        // add reuqest header to POST
+        // add request header to POST
         con.setRequestMethod("POST");
 
         // con.setRequestProperty("User-Agent", USER_AGENT);
         con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
 
-        String urlParameters = "tool=flymine&db=pubmed&rettype=abstract&retmode=xml&id="
+        String urlParameters = "tool=intermine&db=pubmed&rettype=abstract&retmode=xml&id="
             + StringUtil.join(ids, ",");
 
         // Send post request

--- a/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
+++ b/bio/sources/update-publications/main/src/org/intermine/bio/dataconversion/EntrezPublicationsRetriever.java
@@ -365,28 +365,29 @@ public class EntrezPublicationsRetriever
          * Author: Norbert Auer
          * e-mail: norbert.auer@boku.ac.at
          */
-         String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
-         URL obj = new URL(url);
-         HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
+        String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
+        URL obj = new URL(url);
+        HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
 
-         // add reuqest header to POST
-         con.setRequestMethod("POST");
+        // add reuqest header to POST
+        con.setRequestMethod("POST");
 
-         // con.setRequestProperty("User-Agent", USER_AGENT);
-         con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
+        // con.setRequestProperty("User-Agent", USER_AGENT);
+        con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
 
-         String urlParameters = "tool=flymine&db=pubmed&rettype=abstract&retmode=xml&id=" + StringUtil.join(ids, ",");
+        String urlParameters = "tool=flymine&db=pubmed&rettype=abstract&retmode=xml&id="
+            + StringUtil.join(ids, ",");
 
-         // Send post request
-         con.setDoOutput(true);
-         DataOutputStream wr = new DataOutputStream(con.getOutputStream());
-         wr.writeBytes(urlParameters);
-         wr.flush();
-         wr.close();
+        // Send post request
+        con.setDoOutput(true);
+        DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+        wr.writeBytes(urlParameters);
+        wr.flush();
+        wr.close();
 
-         int responseCode = con.getResponseCode();
+        int responseCode = con.getResponseCode();
 
-         return new BufferedReader(new InputStreamReader(con.getInputStream()));
+        return new BufferedReader(new InputStreamReader(con.getInputStream()));
     }
 
     private Set<Item> mapToItems(ItemFactory factory, Map map) {


### PR DESCRIPTION
## Details

*Fix an issue with the getReader() function in EntrezPublicationsRetriever.java file. update-publications always fail, if too much pubmed ids are send to Entrez server. This is because getReader() uses HTTP GET method to send the request. The message size or url length is limited when HTTP GET method is used. Change function to use HTTP POST method instead of HTTP GET method which is not limited by length.*