### PR TITLE
Versioned postprocesses

### DIFF
--- a/bio/sources/build.gradle
+++ b/bio/sources/build.gradle
@@ -37,6 +37,12 @@ subprojects {
     repositories {
         mavenLocal()
         jcenter()
+        maven{
+            url "https://dl.bintray.com/intermineorg/intermine/"
+        }
+        maven{
+            url "https://dl.bintray.com/intermineorg/bio/"
+        }
         maven {
             url 'http://www.ebi.ac.uk/intact/maven/nexus/content/repositories/ebi-repo/'
         }

--- a/bio/sources/chado-db/src/main/java/org/intermine/bio/dataconversion/ChadoDBConverter.java
+++ b/bio/sources/chado-db/src/main/java/org/intermine/bio/dataconversion/ChadoDBConverter.java
@@ -165,7 +165,6 @@ public class ChadoDBConverter extends BioDBConverter
      * Return a map from chado organism id to OrganismData for the organisms in the organism table
      * in chado.  This is a protected method so that it can be overriden for testing
      * @param conn the db connection
-     * @param organismsToProcess organisms to process
      * @return a Map from abbreviation to chado organism_id
      * @throws SQLException if the is a database problem
      */

--- a/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
@@ -64,13 +64,9 @@ class DBModelPlugin implements Plugin<Project> {
                 def projectXml = parser.parse(projectXmlFilePath)
                 projectXml.sources.source.each { source ->
                    String version = System.getProperty("bioVersion")
-                    System.out.println("**** bioVersion ${version}")
-                    System.out.println("**** source name ${source.'@name'}")
                     if (source.'@version' != null) {
                         version = source.'@version'
-                        System.out.println("** source version ${version}")
                     }
-                    System.out.println("** final ${version}")
                     if (source.@type == "intermine-items-xml-file") {
                         dbUtils.addBioSourceDependency(source.'@name', version)
                     }

--- a/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
@@ -148,7 +148,7 @@ class DBModelPlugin implements Plugin<Project> {
                 sourceNames.each { sourceName ->
 
                     Source source = intermineProject.sources.get(sourceName)
-                    String sourceVersion = source.version
+                    String sourceVersion = source.getVersion()
                     String sourceType = source.getType()
                     FileTree dataSourceJar = null
                     File sourceKeysFile = null

--- a/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
@@ -63,10 +63,14 @@ class DBModelPlugin implements Plugin<Project> {
                 parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
                 def projectXml = parser.parse(projectXmlFilePath)
                 projectXml.sources.source.each { source ->
-                    if (source.@type == "intermine-items-xml-file") {
-                        dbUtils.addBioSourceDependency(source.'@name', source.'@version')
+                    String version = System.getProperty("bioVersion");
+                    if (source.'@version' != "") {
+                        version = source.'@version'
                     }
-                    dbUtils.addBioSourceDependency(source.'@type', source.'@version')
+                    if (source.@type == "intermine-items-xml-file") {
+                        dbUtils.addBioSourceDependency(source.'@name', version)
+                    }
+                    dbUtils.addBioSourceDependency(source.'@type', version)
                 }
             }
         }

--- a/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
@@ -63,10 +63,14 @@ class DBModelPlugin implements Plugin<Project> {
                 parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
                 def projectXml = parser.parse(projectXmlFilePath)
                 projectXml.sources.source.each { source ->
-                    String version = System.getProperty("bioVersion");
-                    if (source.'@version' != "") {
+                   String version = System.getProperty("bioVersion")
+                    System.out.println("**** bioVersion ${version}")
+                    System.out.println("**** source name ${source.'@name'}")
+                    if (source.'@version' != null) {
                         version = source.'@version'
+                        System.out.println("** source version ${version}")
                     }
+                    System.out.println("** final ${version}")
                     if (source.@type == "intermine-items-xml-file") {
                         dbUtils.addBioSourceDependency(source.'@name', version)
                     }
@@ -157,15 +161,14 @@ class DBModelPlugin implements Plugin<Project> {
                     FileTree dataSourceJar = null
                     File sourceKeysFile = null
 
-                    // use the version set in project XML
-                    String bioVersionPrefix = sourceVersion
-
-                    if (bioVersionPrefix == "") {
-                        // Prefix because actual value of the version string is 2.+ while the real version is 2.0.0
-                        // Also versions might be strings, so can't use regular expressions (eg. RC or SNAPSHOT)
-                        // have to include the version number at all because go-annotation will match go
-                        bioVersionPrefix = System.getProperty("bioVersion").substring(0, 1)
+                    // Prefix because actual value of the version string is 2.+ while the real version is 2.0.0
+                    // Also versions might be strings, so can't use regular expressions (eg. RC or SNAPSHOT)
+                    // have to include the version number at all because go-annotation will match go
+                    String bioVersionPrefix = System.getProperty("bioVersion").substring(0, 1)
+                    if (sourceVersion != null && sourceVersion != "") {
+                        bioVersionPrefix = sourceVersion
                     }
+
 
                     project.configurations.getByName("mergeSource").asFileTree.each {
                         if (it.name.startsWith("bio-source-$sourceName-$bioVersionPrefix")) {

--- a/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
@@ -64,9 +64,9 @@ class DBModelPlugin implements Plugin<Project> {
                 def projectXml = parser.parse(projectXmlFilePath)
                 projectXml.sources.source.each { source ->
                     if (source.@type == "intermine-items-xml-file") {
-                        dbUtils.addBioSourceDependency(source.'@name', 'source.@version')
+                        dbUtils.addBioSourceDependency(source.'@name', source.'@version')
                     }
-                    dbUtils.addBioSourceDependency(source.'@type', 'source.@version')
+                    dbUtils.addBioSourceDependency(source.'@type', source.'@version')
                 }
             }
         }

--- a/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelPlugin.groovy
@@ -64,9 +64,9 @@ class DBModelPlugin implements Plugin<Project> {
                 def projectXml = parser.parse(projectXmlFilePath)
                 projectXml.sources.source.each { source ->
                     if (source.@type == "intermine-items-xml-file") {
-                        dbUtils.addBioSourceDependency(source.'@name')
+                        dbUtils.addBioSourceDependency(source.'@name', 'source.@version')
                     }
-                    dbUtils.addBioSourceDependency(source.'@type')
+                    dbUtils.addBioSourceDependency(source.'@type', 'source.@version')
                 }
             }
         }
@@ -148,14 +148,20 @@ class DBModelPlugin implements Plugin<Project> {
                 sourceNames.each { sourceName ->
 
                     Source source = intermineProject.sources.get(sourceName)
+                    String sourceVersion = source.version
                     String sourceType = source.getType()
                     FileTree dataSourceJar = null
                     File sourceKeysFile = null
 
-                    // Prefix because actual value of the version string is 2.+ while the real version is 2.0.0
-                    // Also versions might be strings, so can't use regular expressions (eg. RC or SNAPSHOT)
-                    // have to include the version number at all because go-annotation will match go
-                    String bioVersionPrefix = System.getProperty("bioVersion").substring(0, 1)
+                    // use the version set in project XML
+                    String bioVersionPrefix = sourceVersion
+
+                    if (bioVersionPrefix == "") {
+                        // Prefix because actual value of the version string is 2.+ while the real version is 2.0.0
+                        // Also versions might be strings, so can't use regular expressions (eg. RC or SNAPSHOT)
+                        // have to include the version number at all because go-annotation will match go
+                        bioVersionPrefix = System.getProperty("bioVersion").substring(0, 1)
+                    }
 
                     project.configurations.getByName("mergeSource").asFileTree.each {
                         if (it.name.startsWith("bio-source-$sourceName-$bioVersionPrefix")) {

--- a/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelUtils.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelUtils.groovy
@@ -27,10 +27,14 @@ class DBModelUtils {
         file.createNewFile()
     }
 
-    protected addBioSourceDependency = { sourcePostfix ->
+    protected addBioSourceDependency = { sourcePostfix, sourceVersion ->
         DependencyHandler dh = project.getDependencies()
+        String version = System.getProperty("bioVersion");
+        if (sourceVersion != "") {
+            version = sourceVersion
+        }
         Dependency dep = dh.create(
-                [group: "org.intermine", name: "bio-source-${sourcePostfix}", version: System.getProperty("bioVersion")])
+                [group: "org.intermine", name: "bio-source-${sourcePostfix}", version: version])
 
         // This can prove useful for debugging but may be a bit too noisy in practice
         // System.out.println("Adding mergeSource configuration dependency ${dep}")

--- a/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelUtils.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/dbmodel/DBModelUtils.groovy
@@ -29,12 +29,8 @@ class DBModelUtils {
 
     protected addBioSourceDependency = { sourcePostfix, sourceVersion ->
         DependencyHandler dh = project.getDependencies()
-        String version = System.getProperty("bioVersion");
-        if (sourceVersion != "") {
-            version = sourceVersion
-        }
         Dependency dep = dh.create(
-                [group: "org.intermine", name: "bio-source-${sourcePostfix}", version: version])
+                [group: "org.intermine", name: "bio-source-${sourcePostfix}", version: "${sourceVersion}"])
 
         // This can prove useful for debugging but may be a bit too noisy in practice
         // System.out.println("Adding mergeSource configuration dependency ${dep}")

--- a/plugin/src/main/groovy/org/intermine/plugin/integrate/IntegratePlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/integrate/IntegratePlugin.groovy
@@ -52,7 +52,7 @@ class IntegratePlugin implements Plugin<Project> {
                     sourceNames = Arrays.asList(sourceInput.split("\\s*,\\s*"))
                 }
 
-                project.dependencies.add("bioCore", [group: "org.intermine", name: "bio-core", version: System.getProperty("imVersion"), transitive: false])
+                project.dependencies.add("bioCore", [group: "org.intermine", name: "bio-core", version: System.getProperty("bioVersion"), transitive: false])
 
                 // keep track of the versions, only take the first one encountered
                 Map<String, String> typesToVersions = new HashMap<String, String>()

--- a/plugin/src/main/groovy/org/intermine/plugin/postprocess/PostProcessPlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/postprocess/PostProcessPlugin.groovy
@@ -47,7 +47,7 @@ class PostProcessPlugin implements Plugin<Project> {
                     // default version
                     String version = System.getProperty("bioVersion")
                     // check if we have a custom version
-                    } if (postProcess.version != null) {
+                    if (postProcess.version != null) {
                         version = postProcess.version
                     }
 

--- a/plugin/src/main/groovy/org/intermine/plugin/postprocess/PostProcessPlugin.groovy
+++ b/plugin/src/main/groovy/org/intermine/plugin/postprocess/PostProcessPlugin.groovy
@@ -43,8 +43,16 @@ class PostProcessPlugin implements Plugin<Project> {
                     if (postProcess == null) {
                         throw new InvalidUserDataException("Can't find postProcess " + processName + " in project definition file")
                     }
+
+                    // default version
+                    String version = System.getProperty("bioVersion")
+                    // check if we have a custom version
+                    } if (postProcess.version != null) {
+                        version = postProcess.version
+                    }
+
                     if (!DO_SOURCES.equals(processName)) {
-                        project.dependencies.add("postProcesses", [group: "org.intermine", name: "bio-postprocess-" + processName, version: System.getProperty("bioVersion")])
+                        project.dependencies.add("postProcesses", [group: "org.intermine", name: "bio-postprocess-" + processName, version: postProcess])
                     }
                 }
             }

--- a/plugin/src/main/java/org/intermine/plugin/project/PostProcess.java
+++ b/plugin/src/main/java/org/intermine/plugin/project/PostProcess.java
@@ -16,5 +16,21 @@ package org.intermine.plugin.project;
  */
 public class PostProcess extends Action
 {
-    // empty
+    private String version;
+
+    /**
+     * Set the version of this Source, e.g. 2.0.0
+     * @param version the version
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Get the version of this object.
+     * @return the version
+     */
+    public String getVersion() {
+        return version;
+    }
 }

--- a/plugin/src/main/java/org/intermine/plugin/project/ProjectXmlBinding.java
+++ b/plugin/src/main/java/org/intermine/plugin/project/ProjectXmlBinding.java
@@ -98,6 +98,10 @@ public final class ProjectXmlBinding
                 }
             } else if ("post-process".equals(qName)) {
                 PostProcess postProcess = new PostProcess();
+                String version = attrs.getValue("version");
+                if (version != null && !"".equals(version)) {
+                    postProcess.setVersion(version);
+                }
                 action = postProcess;
                 project.addPostProcess(attrs.getValue("name"), postProcess);
             } else if ("source".equals(qName)) {


### PR DESCRIPTION
## Details

Users need to be able to version their sources. I did this in #1899. However I missed two things:

* Postprocesses need to be versioned in the same way
* Generating the keys file to use also puts bio-sources on the classpath and needs to use the custom version. I don't know how I missed that in the original commit? 

## Testing

* Versioning sources works with and without a version specified in project XML file
* Versioning postprocesses works with and without a version specified in project XML file

I don't know how I missed the keys thing, so please be sure to clean. However, I am pretty sure I _did_ do a clean. The code worked on FlyMine and locally but NOT in HumanMine. Don't know why. 

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle

(I haven't done documentation yet)