### PR TITLE
if the XML does not validate, don't check for DTD. Refs #1914

### DIFF
--- a/bio/sources/interpro/src/main/java/org/intermine/bio/dataconversion/InterProConverter.java
+++ b/bio/sources/interpro/src/main/java/org/intermine/bio/dataconversion/InterProConverter.java
@@ -12,12 +12,15 @@ package org.intermine.bio.dataconversion;
 
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Stack;
 
 import org.intermine.dataconversion.ItemWriter;
 import org.intermine.metadata.Model;
+import org.intermine.metadata.StringUtil;
 import org.intermine.objectstore.ObjectStoreException;
 import org.intermine.util.SAXParser;
 import org.intermine.xml.full.Item;
@@ -54,7 +57,7 @@ public class InterProConverter extends BioFileConverter
     public void process(Reader reader) throws Exception {
         InterProHandler handler = new InterProHandler(getItemWriter());
         try {
-            SAXParser.parse(new InputSource(reader), handler);
+            SAXParser.parse(new InputSource(reader), handler, false);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException(e);

--- a/intermine/objectstore/src/main/java/org/intermine/util/SAXParser.java
+++ b/intermine/objectstore/src/main/java/org/intermine/util/SAXParser.java
@@ -56,6 +56,11 @@ public final class SAXParser
         try {
             SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setValidating(validate);
+            if (!validate) {
+                factory.setFeature(
+                        "http://apache.org/xml/features/nonvalidating/load-external-dtd",
+                        false);
+            }
             factory.newSAXParser().parse(is, handler);
         } catch (ParserConfigurationException e) {
             ParserConfigurationException e2 = new ParserConfigurationException("The underlying "


### PR DESCRIPTION
## Details

See #1914 . Basically the InterPro XML comes with an invalid DTD file. It says "interpro.dtd" instead of the full path. This code turns off validation when parsing this XML file. A bad idea? 

The alternative would be for the user to:

* download the DTD (along with the data)
* add that location to the project XML file
* have the build copy the DTD to the classpath?

I know ignoring the DTD is bad practice but the path is wrong.

The InterMine SAX parser method has a boolean to validate or not. However, even when validate = FALSE, you still get a file not found because it still looks for the DTD. I've fixed this.

## Testing

* builds work as expected (will test this)
* interpro source works as expected (I have tested this)

I am more looking for a code review.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
