### PR TITLE
GFF: add header

### DIFF
--- a/bio/core/src/main/java/org/intermine/bio/io/gff3/GFF3Parser.java
+++ b/bio/core/src/main/java/org/intermine/bio/io/gff3/GFF3Parser.java
@@ -36,8 +36,7 @@ public final class GFF3Parser
      */
     public static Iterator<?> parse(final BufferedReader reader) throws IOException {
         String line = null;
-        StringBuilder header = new StringBuilder();
-        boolean processHeader = true;
+        StringBuilder headerBuilder = new StringBuilder();
 
         while ((line = reader.readLine()) != null) {
             String trimmedLine = line.trim();
@@ -47,21 +46,19 @@ public final class GFF3Parser
             }
 
             // gather up the header information.
-            if (trimmedLine.startsWith("#") && processHeader) {
-                header.append(trimmedLine);
+            if (trimmedLine.startsWith("#")) {
+                headerBuilder.append(trimmedLine);
                 continue;
             }
 
-            // there are lines that start with # later on in the file. We don't want them!
-            processHeader = false;
-
             // throws IOException if the first GFF line isn't valid
-            new GFF3Record(header.toString(), trimmedLine);
+            new GFF3Record(headerBuilder.toString(), trimmedLine);
 
             break;
         }
 
         final String firstGFFLine = line;
+        final String header =  headerBuilder.toString();
 
         return new Iterator<Object>() {
             String currentLine = firstGFFLine;
@@ -77,16 +74,10 @@ public final class GFF3Parser
                 }
                 Object objectToReturn = null;
                 try {
-                    objectToReturn = new GFF3Record(header.toString(), currentLine);
+                    objectToReturn = new GFF3Record(header, currentLine);
                     while ((currentLine = reader.readLine()) != null) {
                         String trimmedLine = currentLine.trim();
-                        if (trimmedLine.length() == 0) {
-                            continue;
-                        }
-
-                        // gather up the header information.
-                        if (trimmedLine.startsWith("#")) {
-                            header.append(trimmedLine);
+                        if (trimmedLine.length() == 0 || trimmedLine.startsWith("#")) {
                             continue;
                         }
                         break;

--- a/bio/core/src/main/java/org/intermine/bio/io/gff3/GFF3Parser.java
+++ b/bio/core/src/main/java/org/intermine/bio/io/gff3/GFF3Parser.java
@@ -36,7 +36,8 @@ public final class GFF3Parser
      */
     public static Iterator<?> parse(final BufferedReader reader) throws IOException {
         String line = null;
-        StringBuffer header = new StringBuffer();
+        StringBuilder header = new StringBuilder();
+        boolean processHeader = true;
 
         while ((line = reader.readLine()) != null) {
             String trimmedLine = line.trim();
@@ -46,10 +47,13 @@ public final class GFF3Parser
             }
 
             // gather up the header information.
-            if (trimmedLine.startsWith("#")) {
+            if (trimmedLine.startsWith("#") && processHeader) {
                 header.append(trimmedLine);
                 continue;
             }
+
+            // there are lines that start with # later on in the file. We don't want them!
+            processHeader = false;
 
             // throws IOException if the first GFF line isn't valid
             new GFF3Record(header.toString(), trimmedLine);

--- a/bio/core/src/main/java/org/intermine/bio/io/gff3/GFF3Parser.java
+++ b/bio/core/src/main/java/org/intermine/bio/io/gff3/GFF3Parser.java
@@ -36,16 +36,23 @@ public final class GFF3Parser
      */
     public static Iterator<?> parse(final BufferedReader reader) throws IOException {
         String line = null;
+        StringBuffer header = new StringBuffer();
 
         while ((line = reader.readLine()) != null) {
             String trimmedLine = line.trim();
 
-            if (trimmedLine.length() == 0 || trimmedLine.startsWith("#")) {
+            if (trimmedLine.length() == 0) {
+                continue;
+            }
+
+            // gather up the header information.
+            if (trimmedLine.startsWith("#")) {
+                header.append(trimmedLine);
                 continue;
             }
 
             // throws IOException if the first GFF line isn't valid
-            new GFF3Record(trimmedLine);
+            new GFF3Record(header.toString(), trimmedLine);
 
             break;
         }
@@ -66,10 +73,16 @@ public final class GFF3Parser
                 }
                 Object objectToReturn = null;
                 try {
-                    objectToReturn = new GFF3Record(currentLine);
+                    objectToReturn = new GFF3Record(header.toString(), currentLine);
                     while ((currentLine = reader.readLine()) != null) {
                         String trimmedLine = currentLine.trim();
-                        if (trimmedLine.length() == 0 || trimmedLine.startsWith("#")) {
+                        if (trimmedLine.length() == 0) {
+                            continue;
+                        }
+
+                        // gather up the header information.
+                        if (trimmedLine.startsWith("#")) {
+                            header.append(trimmedLine);
                             continue;
                         }
                         break;

--- a/bio/core/src/main/java/org/intermine/bio/io/gff3/GFF3Record.java
+++ b/bio/core/src/main/java/org/intermine/bio/io/gff3/GFF3Record.java
@@ -43,6 +43,7 @@ public class GFF3Record
     private String strand;
     private String phase;
     private Map<String, List<String>> attributes = new LinkedHashMap<String, List<String>>();
+    private String header = null;
 
     /**
      * Create a GFF3Record from a line of a GFF3 file
@@ -50,6 +51,21 @@ public class GFF3Record
      * @throws IOException if there is an error during parsing the line
      */
     public GFF3Record(String line) throws IOException {
+        parseLine(line);
+    }
+
+    /**
+     * Create a GFF3Record from a line of a GFF3 file
+     * @param line the String to parse
+     * @param header the comments at the beginning of the GFF file. Might be null
+     * @throws IOException if there is an error during parsing the line
+     */
+    public GFF3Record(String header, String line) throws IOException {
+        parseLine(line);
+        this.header = header;
+    }
+
+    private void parseLine(String line) throws IOException {
         StringTokenizer st = new StringTokenizer(line, "\t", false);
 
         if (st.countTokens() < 8) {
@@ -71,7 +87,7 @@ public class GFF3Record
             }
         } catch (NumberFormatException nfe) {
             throw new IOException("can not parse integer for start position: " + startString
-                                  + " from line: " + line);
+                    + " from line: " + line);
         }
 
         String endString = st.nextToken().trim();
@@ -83,7 +99,7 @@ public class GFF3Record
             }
         } catch (NumberFormatException nfe) {
             throw new IOException("can not parse integer for end position: " + endString
-                                  + " from line: " + line);
+                    + " from line: " + line);
         }
 
         String scoreString = st.nextToken().trim();
@@ -95,7 +111,7 @@ public class GFF3Record
                 score = new Double(scoreString);
             } catch (NumberFormatException nfe) {
                 throw new IOException("can not parse score: " + scoreString + " from line: "
-                                      + line);
+                        + line);
             }
         }
 
@@ -409,6 +425,15 @@ public class GFF3Record
      */
     public Map<String, List<String>> getAttributes () {
         return attributes;
+    }
+
+    /**
+     * Return the value of the top of the GFF file, any line that starts with #.
+     *
+     * @return the file header -- the comments at the top of the GFF file
+     */
+    public String getHeader () {
+        return header;
     }
 
     /**


### PR DESCRIPTION
## Details

The header of the GFF file (the top bit that has a #) often has important metadata, such as the genome build, date of annotation, etc. but is discarded.

Instead, I set the header to a variable, and made that variable available in the `GFFRecord`

See: #1786

## Testing

@sergiocontrino Can you test that the GFF loading still works as expected? I only changed the constructor.

@JoelRichardson Can you verify this is what you asked for?

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
