### PR TITLE
Update Java client to use Gradle

### DIFF
--- a/intermine/api/src/main/java/org/intermine/api/query/codegen/WebserviceJavaCodeGenerator.java
+++ b/intermine/api/src/main/java/org/intermine/api/query/codegen/WebserviceJavaCodeGenerator.java
@@ -298,7 +298,7 @@ public class WebserviceJavaCodeGenerator implements WebserviceCodeGenerator
 
         intermineImports.addAll(Arrays.asList(
                 "org.intermine.metadata.Model",
-                "org.intermine.webservice.client.core.ServiceFactory",
+                "org.intermine.client.core.ServiceFactory",
                 "org.intermine.pathquery.PathQuery"));
 
 
@@ -427,7 +427,7 @@ public class WebserviceJavaCodeGenerator implements WebserviceCodeGenerator
         javaImports.add("java.util.Iterator");
         javaImports.add("java.io.PrintStream");
 
-        intermineImports.add("org.intermine.webservice.client.services.QueryService");
+        intermineImports.add("org.intermine.client.services.QueryService");
 
         codeBody.append(INDENT2 + "QueryService service = factory.getQueryService();" + endl);
         codeBody.append(INDENT2 + INIT_OUT + endl);
@@ -500,8 +500,8 @@ public class WebserviceJavaCodeGenerator implements WebserviceCodeGenerator
         codeBody.append(getIntro(info));
         codeBody.append(generateStartOfClass(info, "TemplateQuery" + srcClassName));
 
-        intermineImports.add("org.intermine.webservice.client.core.ServiceFactory");
-        intermineImports.add("org.intermine.webservice.client.template.TemplateParameter");
+        intermineImports.add("org.intermine.client.core.ServiceFactory");
+        intermineImports.add("org.intermine.client.template.TemplateParameter");
         javaImports.addAll(Arrays.asList("java.util.List", "java.util.ArrayList",
                 "java.io.IOException"));
 
@@ -531,7 +531,7 @@ public class WebserviceJavaCodeGenerator implements WebserviceCodeGenerator
         }
 
         codeBody.append(endl);
-        intermineImports.add("org.intermine.webservice.client.services.TemplateService");
+        intermineImports.add("org.intermine.client.services.TemplateService");
         javaImports.add("java.util.Iterator");
 
         // Add display results code

--- a/intermine/webapp/src/main/webapp/apiJava.jsp
+++ b/intermine/webapp/src/main/webapp/apiJava.jsp
@@ -21,23 +21,35 @@
 <div>
   The Java web service client library makes it easy to run queries in <c:out value="${WEB_PROPERTIES['project.title']}"/> directly from Java programs.
   You can use this libray to construct any query you could run from web interface and fetch the results
-  in as either tables of values, or JSON data structures (see <a href="http://json.org">json.org</a>).
+  in as either tables of values, or JSON data structures.
   <br/>
   Like all our code, these client libraries are open-source, licensed under the LGPL. For information
   on the API visit our <a href="${wiki}">wiki pages</a>, and for Javadoc please visit the
-  <a href="http://intermine.github.io/intermine/">API documentation</a> (paying special
-  attention to the classes in the <code>org.intermine.pathquery</code> and
-  <code>org.intermine.webservice.client</code> packages).
+  <a href="http://intermine.org/intermine-ws-java/javadoc/">API documentation</a>.
 </div>
 <br>
 <div>
   <ul>
     <li>
-      <div onclick="javascript:showText('prerequisite')"><h3 style="font-weight: bold;">Prerequisites</h3></div>
+      <div onclick="javascript:showText('prerequisite')"><h3 style="font-weight: bold;">Get the library</h3></div>
       <div id="prerequisite" style="padding: 5px">
-        <p>All you need is java 1.8+ and our package
-    (<a href="https://github.com/intermine/intermine-ws-java/raw/master/download/dist/java-intermine-webservice-client-2.0.zip">download</a>)
-        which contains the client library and all dependencies.
+        <p>Maven
+
+        <pre>
+            &lt;!-- https://bintray.com/intermineorg/java-client--&gt;
+            &lt;dependency&gt;
+                &lt;groupId&gt;org.intermine&lt;/groupId&gt;
+                &lt;artifactId&gt;intermine-ws-java&lt;/artifactId&gt;
+                &lt;version&gt;3.0.+&lt;/version&gt;
+            &lt;/dependency&gt;
+        </pre>
+        </p>
+        <p>
+        Gradle
+        <br>
+        <pre>compile 'org.intermine:intermine-ws-java:3.0.+'</pre>
+        </p>
+
       </p>
       </div>
     </li>
@@ -54,39 +66,6 @@
               From a Template Query form - click the "Java" link below the template form.
             </li>
           </ul>
-      </div>
-    </li>
-    <li>
-      <div onclick="javascript:showText('editsrc')"><h3 style="font-weight: bold;">Run the program</h3></div>
-      <div id="editsrc" style="padding: 5px">
-        <span>You can run the program either from the command line or within an IDE (e.g. Eclipse).
-    To run the program in your favorite IDE, make sure to import all the libs from the distribution package. To run from command line:</span>
-           <ol style="padding:0px">
-            <li>
-              Unzip the distribution package (see above):<br>
-                <pre>&gt; unzip java-intermine-webservice-client-2.0.zip</pre>
-            </li>
-            <li>
-              <c:set var="dirName" value="${javasieProjectTitle}"/>
-
-              In the intermine-webservice-client-x.x directory that has been created make a new directory called
-              <code><c:out value="${dirName}"/></code> (this is the package name in the generated Java).<br>
-        <pre>&gt; cd ${fn:substringBefore(fileName, ".zip")}
-&gt; mkdir ${dirName}</pre>
-            </li>
-      <li>
-              Save the source code in a Java source file (*.java) in the <c:out value="${dirName}"/>
-        directory. The file name and the class name
-        have to be the same. The generated class names might be duplicated (if you have generated
-        code for a query before) - feel free to change them if necessary. For example, the
-    default query class name is <code>QueryClient</code>, so:<br>
-    <pre>&gt; cp [downloaded-file] ${dirName}/QueryClient.java</pre>
-            </li>
-            <li>
-              Run the script from the command line under the package directory:<br>
-      <pre>&gt; sh compile-run.sh <c:out value="${dirName}"/>.QueryClient</pre>
-            </li>
-          </ol>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
## Details

There was a small bug in the Java client but I couldn't fix because the compile scripts rely on having the old local JARs.

I've updated the Java client to use the new gradle build system.

* [client](https://github.com/intermine/intermine-ws-java)
* [examples](https://github.com/intermine/intermine-ws-java-docs)
* [javadoc](http://intermine.org/intermine-ws-java/javadoc/)
* [user docs](https://intermine.readthedocs.io/en/latest/web-services/#api-and-client-libraries)

## Testing

* Docs are complete
* Autogenerate is correct
* Examples work. 
* Travis passes

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
