### PR TITLE
BAR ThaleMine - 3

### DIFF
--- a/bio/sources/panther/src/main/java/org/intermine/bio/dataconversion/PantherConverter.java
+++ b/bio/sources/panther/src/main/java/org/intermine/bio/dataconversion/PantherConverter.java
@@ -143,6 +143,12 @@ public class PantherConverter extends BioFileConverter
             return null;
         }
 
+        // A. thaliana bug fix for Gene IDs.
+        // Example: At5g04395 is stored as two different genes: At5g04395 and AT5G04395.
+        if ("3702".equals(taxonId)) {
+	    resolvedGenePid = resolvedGenePid.toUpperCase();
+	}
+
         // only resolve if fish - TODO put in config file
         if ("7955".equals(taxonId) || "9606".equals(taxonId) || "10116".equals(taxonId)) {
             resolvedGenePid = resolveGene(taxonId, resolvedGenePid);

--- a/bio/sources/panther/src/main/java/org/intermine/bio/dataconversion/PantherConverter.java
+++ b/bio/sources/panther/src/main/java/org/intermine/bio/dataconversion/PantherConverter.java
@@ -146,8 +146,8 @@ public class PantherConverter extends BioFileConverter
         // A. thaliana bug fix for Gene IDs.
         // Example: At5g04395 is stored as two different genes: At5g04395 and AT5G04395.
         if ("3702".equals(taxonId)) {
-	    resolvedGenePid = resolvedGenePid.toUpperCase();
-	}
+            resolvedGenePid = resolvedGenePid.toUpperCase();
+        }
 
         // only resolve if fish - TODO put in config file
         if ("7955".equals(taxonId) || "9606".equals(taxonId) || "10116".equals(taxonId)) {


### PR DESCRIPTION
## Details

This is another pull request regarding ThaleMine 4.1.0 upgrade. This pull request converts Arabidopsis (Taxon 3702) gene IDs to uppercase for Panther data loader. If IDs are not converted to uppercase, Intermine ends up creating two gene ID records with two gene report pages. For example, one record is created for At5g04395 and another for AT5G04395.

Please see our working version of Panther data source override here:
[https://github.com/asherpasha/thalemine-bio-sources](https://github.com/asherpasha/thalemine-bio-sources)

## Testing

Travis testing.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [x] Passing unit test for new or updated code (if applicable)
- [x] Passes all tests – according to Travis
- [x] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [x] Checkstyle
