### PR TITLE
correct the cast conversion when updating serial

### DIFF
--- a/intermine/objectstore/src/main/java/org/intermine/task/GenerateUpdateTriggersTask.java
+++ b/intermine/objectstore/src/main/java/org/intermine/task/GenerateUpdateTriggersTask.java
@@ -1018,7 +1018,7 @@ public class GenerateUpdateTriggersTask extends Task
          */
         return "DROP SEQUENCE im_post_build_insert_serial;\n"
                 + "SELECT setval('serial',\n"
-                + "(select ((max(max)-1)/1000000)::int FROM \n"
+                + "(select floor((max(max)-1)/1000000)::int FROM \n"
                 + "(SELECT max(id) FROM intermineobject UNION \n"
                 + " SELECT max(id)+2::bigint^32 AS max FROM intermineobject WHERE id < 0) _z));\n";
     }


### PR DESCRIPTION
## Details

You learn something new everyday. The SQL standard for casting a float to an integer rounds to the nearest integer; it does not truncate. When calculating the value for the serial after (possibly) adding new IntermineObjects into the database with remove_update_triggers.sql, I needed to add an explicit floor() function call.

## Testing

When the maximum id of IntermineObject divided by 1,000,000 rounds up to an integer, the value of serial should be the floor of the maximum id divided by 1,000,000.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
