### PR TITLE
Update WebservicePythonCodeGenerator.java

### DIFF
--- a/intermine/api/src/main/java/org/intermine/api/query/codegen/WebservicePythonCodeGenerator.java
+++ b/intermine/api/src/main/java/org/intermine/api/query/codegen/WebservicePythonCodeGenerator.java
@@ -510,7 +510,7 @@ public class WebservicePythonCodeGenerator implements WebserviceCodeGenerator
         }
 
         if (code != null) {
-            sb.append(", code = \"" + code + "\""); // kwargs
+            sb.append(", code=\"" + code + "\""); // kwargs
         }
         sb.append(")" + endl);
         return sb.toString();

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/eq-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/eq-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/eq-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/eq-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("secondaryIdentifier", "=", "zen", code = "A")
+query.add_constraint("secondaryIdentifier", "=", "zen", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/ge-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/ge-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/ge-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/ge-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,11 +31,11 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("length", ">=", "1024", code = "A")
+query.add_constraint("length", ">=", "1024", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")
 
 for row in query.rows():
     print(row["primaryIdentifier"], row["secondaryIdentifier"], row["symbol"], row["name"], \
-        row["organism.shortName"])
+          row["organism.shortName"])

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/gt-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/gt-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/gt-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/gt-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,11 +31,11 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("length", ">", "1024", code = "A")
+query.add_constraint("length", ">", "1024", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")
 
 for row in query.rows():
     print(row["primaryIdentifier"], row["secondaryIdentifier"], row["symbol"], row["name"], \
-        row["organism.shortName"])
+          row["organism.shortName"])

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/in-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/in-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/in-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/in-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,11 +31,11 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("Gene", "IN", "aList", code = "A")
+query.add_constraint("Gene", "IN", "aList", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")
 
 for row in query.rows():
     print(row["primaryIdentifier"], row["secondaryIdentifier"], row["symbol"], row["name"], \
-        row["organism.shortName"])
+          row["organism.shortName"])

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/isnull-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/isnull-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,11 +31,11 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("primaryIdentifier", "IS NULL", code = "A")
+query.add_constraint("primaryIdentifier", "IS NULL", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")
 
 for row in query.rows():
     print(row["primaryIdentifier"], row["secondaryIdentifier"], row["symbol"], row["name"], \
-        row["organism.shortName"])
+          row["organism.shortName"])

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/le-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/le-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/le-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/le-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,11 +31,11 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("length", "<=", "1024", code = "A")
+query.add_constraint("length", "<=", "1024", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")
 
 for row in query.rows():
     print(row["primaryIdentifier"], row["secondaryIdentifier"], row["symbol"], row["name"], \
-        row["organism.shortName"])
+          row["organism.shortName"])

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/like-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/like-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/like-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/like-constraint.python.expected
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+  #!/usr/bin/env python
 
 # This is an automatically generated script to run your query
 # to use it you will require the intermine python client.
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,11 +31,11 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("organism.commonName", "LIKE", "D.*", code = "A")
+query.add_constraint("organism.commonName", "LIKE", "D.*", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")
 
 for row in query.rows():
     print(row["primaryIdentifier"], row["secondaryIdentifier"], row["symbol"], row["name"], \
-        row["organism.shortName"])
+          row["organism.shortName"])

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/lookup-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/lookup-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/lookup-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/lookup-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,12 +31,12 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("Gene", "LOOKUP", "zen", "C. elegans", code = "A")
-query.add_constraint("Gene", "LOOKUP", "eve", code = "B")
+query.add_constraint("Gene", "LOOKUP", "zen", "C. elegans", code="A")
+query.add_constraint("Gene", "LOOKUP", "eve", code="B")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A and B")
 
 for row in query.rows():
     print(row["primaryIdentifier"], row["secondaryIdentifier"], row["symbol"], row["name"], \
-        row["organism.shortName"])
+          row["organism.shortName"])

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/loopeq-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/loopeq-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/loopeq-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/loopeq-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -24,7 +25,7 @@ query = service.new_query("Employee")
 query.add_view("name", "department.name")
 
 # You can edit the constraint values below
-query.add_constraint("department.manager", "IS", "department.company.CEO", code = "A")
+query.add_constraint("department.manager", "IS", "department.company.CEO", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/loopne-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/loopne-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -24,7 +25,7 @@ query = service.new_query("Employee")
 query.add_view("name", "department.name")
 
 # You can edit the constraint values below
-query.add_constraint("department.manager", "IS NOT", "department.company.CEO", code = "A")
+query.add_constraint("department.manager", "IS NOT", "department.company.CEO", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/loopne-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/loopne-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/lt-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/lt-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/lt-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/lt-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("length", "<", "1024", code = "A")
+query.add_constraint("length", "<", "1024", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/multiple-constraints.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/multiple-constraints.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/multiple-constraints.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/multiple-constraints.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -24,9 +25,9 @@ query = service.new_query("Employee")
 query.add_view("name", "department.name")
 
 # You can edit the constraint values below
-query.add_constraint("department.manager", "IS NOT", "department.company.CEO", code = "A")
-query.add_constraint("Employee", "LOOKUP", "M*", code = "B")
-query.add_constraint("department.name", "ONE OF", ["Sales", "Warehouse"], code = "C")
+query.add_constraint("department.manager", "IS NOT", "department.company.CEO", code="A")
+query.add_constraint("Employee", "LOOKUP", "M*", code="B")
+query.add_constraint("department.name", "ONE OF", ["Sales", "Warehouse"], code="C")
 
 # Your custom constraint logic is specified with the code below:
 query.set_logic("(A or C) and B")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/neq-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/neq-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/neq-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/neq-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("secondaryIdentifier", "!=", "zen", code = "A")
+query.add_constraint("secondaryIdentifier", "!=", "zen", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/noneof-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/noneof-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("organism.commonName", "NONE OF", ["fruit fly", "honey bee"], code = "A")
+query.add_constraint("organism.commonName", "NONE OF", ["fruit fly", "honey bee"], code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/noneof-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/noneof-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/notin-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/notin-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/notin-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/notin-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("Gene", "NOT IN", "aList", code = "A")
+query.add_constraint("Gene", "NOT IN", "aList", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/notlike-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/notlike-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/notlike-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/notlike-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("organism.commonName", "NOT LIKE", "D.*", code = "A")
+query.add_constraint("organism.commonName", "NOT LIKE", "D.*", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/notnull-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/notnull-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/notnull-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/notnull-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("primaryIdentifier", "IS NOT NULL", code = "A")
+query.add_constraint("primaryIdentifier", "IS NOT NULL", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/oneof-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/oneof-constraint.python.expected
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
-
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/oneof-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/oneof-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("organism.commonName", "ONE OF", ["fruit fly", "honey bee"], code = "A")
+query.add_constraint("organism.commonName", "ONE OF", ["fruit fly", "honey bee"], code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")

--- a/intermine/api/src/test/resources/org/intermine/api/query/codegen/private-in-constraint.python.expected
+++ b/intermine/api/src/test/resources/org/intermine/api/query/codegen/private-in-constraint.python.expected
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # The following two lines will be needed in every python script:
 from intermine.webservice import Service
+
 service = Service("TEST_SERVICE_ROOT/service", token = "YOUR-API-KEY")
 
 # Get a new query on the class (table) you will be querying:
@@ -30,7 +31,7 @@ query.add_view(
 # query.add_sort_order("Gene.primaryIdentifier", "ASC")
 
 # You can edit the constraint values below
-query.add_constraint("Gene", "IN", "aList", code = "A")
+query.add_constraint("Gene", "IN", "aList", code="A")
 
 # Uncomment and edit the code below to specify your own custom logic:
 # query.set_logic("A")


### PR DESCRIPTION
According to Python's code styling PEP8 there shouldn't be  `unexpected spaces around keyword / parameter equals`

## Details

Check Python's PEP 8 and `unexpected spaces around keyword / parameter equals`

## Testing

Python code generated from the queries should have 

```python
code="A"
```

instead of

```python
code = "A"
```

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ x] Checkstyle