### PR TITLE
Fix organism short name formation.

### DIFF
--- a/bio/sources/entrez-organism/src/main/java/org/intermine/bio/dataconversion/EntrezOrganismRetriever.java
+++ b/bio/sources/entrez-organism/src/main/java/org/intermine/bio/dataconversion/EntrezOrganismRetriever.java
@@ -295,8 +295,14 @@ Example
                                 text.substring(0, spaceIndex));
                         organism.setAttribute("species",
                                 text.substring(spaceIndex + 1));
-                        organism.setAttribute("shortName", text.charAt(0)
-                                + ". " + text.substring(spaceIndex + 1));
+                        // Organism name could have [] in it , as a result the short name will start with [.
+                        // toFix : check if it does not start with [
+                        String shortName = text.charAt(0)
+                                + ". " + text.substring(spaceIndex + 1);
+                        if (text.startsWith("[") ) {
+                            shortName = text.charAt(1) + ". " + text.substring(spaceIndex + 1) ;
+                        }
+                        organism.setAttribute("shortName", shortName);
                     }
                 }
             } else if ("CommonName".equals(name)) {


### PR DESCRIPTION
## Details
I am working on Candidamine for candida species, and some organism that are loaded in the mine start with **[** e.g **[Candida] auris** or **[Candida] glabrata**. This lead to a strange  short name for example **[.auris**.
This fix such behaviour.

*Summary of pull request, including references to relevant tickets (if applicable).*

## Testing

*Besides running unit tests, how can the reviewer test your feature / bug fix? Are there edge cases to be aware of?*

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
