### PR TITLE
BAR ThaleMine - 6: Fixed a minor bug in reports page long fields

### DIFF
--- a/intermine/webapp/src/main/webapp/report.jsp
+++ b/intermine/webapp/src/main/webapp/report.jsp
@@ -126,10 +126,12 @@
     <%-- summary long fields --%>
     <table>
       <c:forEach var="field" items="${object.objectSummaryFields}">
+        <c:set var="fieldDisplayText"
+          value="${imf:formatFieldChain(field.pathString, INTERMINE_API, WEBCONFIG)}"/>
         <c:if test="${field.doNotTruncate}">
           <tr>
             <c:if test="${!empty field.value}">
-              <td class="label">${field.name}&nbsp;<im:typehelp type="${field.pathString}"/></td>
+              <td class="label">${fieldDisplayText}&nbsp;<im:typehelp type="${field.pathString}"/></td>
               <td><strong><c:out escapeXml="${field.escapeXml}" value="${field.value}" /></strong></td>
             </c:if>
           </tr>


### PR DESCRIPTION
## Details

This pull request fixes the following bug in the reports page:

If 'field.doNotTruncate' is set to true, then the label is not displayed correctly. Instead 'field.name' is shown.

## Testing

We have tested the changes in the development version of ThaleMine.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [x] Passing unit test for new or updated code (if applicable)
- [x] Passes all tests – according to Travis
- [x] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [x] Checkstyle
