### PR TITLE
Updated testmine to Gradle 4.9

### DIFF
--- a/testmine/build.gradle
+++ b/testmine/build.gradle
@@ -55,5 +55,5 @@ subprojects {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.1'
+    gradleVersion = '4.9'
 }

--- a/testmine/gradle/wrapper/gradle-wrapper.properties
+++ b/testmine/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION
## Details

This pull request updates testmine Gradle to 4.9. This is required for InterMine Client upgrade to Python 3.8. Please test and merge, so we can test the client on Travis.

Related issue #2271 

## Testing

Travis testing

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [x] Passing unit test for new or updated code (if applicable)
- [x] Passes all tests – according to Travis
- [x] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [x] Checkstyle
