### PR TITLE
Testing OpenJDK8 vs OpenJDK11 on Travis - Do not merge.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python: 2.7
 dist: bionic
 addons:
   postgresql: 11
+services: postgresql
 env:
   global:
   - TESTMODEL_URL=http://localhost:8080/intermine-demo
@@ -17,8 +18,6 @@ env:
 sudo: true
 jdk:
 - openjdk11
-dist: 
-- trusty
 before_script:
 - java -version
 - javac -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python: 2.7
+dist: bionic
 addons:
-  postgresql: 9.6
+  postgresql: 11
 env:
   global:
   - TESTMODEL_URL=http://localhost:8080/intermine-demo
@@ -23,9 +24,6 @@ before_script:
 - javac -version
 - echo $PATH
 - echo $JAVA_HOME
-- jdk_switcher use openjdk11
-- java -version
-- javac -version
 - "./config/travis/init-solr.sh"
 - "./config/travis/init.sh"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ jdk:
 dist: 
 - trusty
 before_script:
+- java -version
+- javac -version
+- echo $PATH
+- echo $JAVA_HOME
+- jdk_switcher use openjdk11
+- java -version
+- javac -version
 - "./config/travis/init-solr.sh"
 - "./config/travis/init.sh"
 script:

--- a/config/travis/init-solr.sh
+++ b/config/travis/init-solr.sh
@@ -1,7 +1,7 @@
 # set up solr for testmine
 # testmine's setup script populates these empty indexes
 
-wget http://archive.apache.org/dist/lucene/solr/7.2.1/solr-7.2.1.tgz  
-tar xzf solr-7.2.1.tgz && ./solr-7.2.1/bin/solr start
-./solr-7.2.1/bin/solr create -c intermine-search
-./solr-7.2.1/bin/solr create -c intermine-autocomplete
+wget http://archive.apache.org/dist/lucene/solr/8.5.2/solr-8.5.2.tgz  
+tar xzf solr-8.5.2.tgz && ./solr-8.5.2/bin/solr start
+./solr-8.5.2/bin/solr create -c intermine-search
+./solr-8.5.2/bin/solr create -c intermine-autocomplete

--- a/testmine/setup.sh
+++ b/testmine/setup.sh
@@ -113,5 +113,5 @@ echo "------> Loading userprofile..."
 
 echo "------> Running webapp"
 echo "------> Running ./gradlew tomcatstartwar"
-./gradlew tomcatstartwar --no-daemon &
+./gradlew cargoRunLocal --no-daemon &
 echo "------> Finished"


### PR DESCRIPTION
## Details

This pull request checks what version of OpenJDK is working on Travis CI system. We have good reasons to believe that OpenJDK 8 is still running despite specifying "jdk: openjdk11" in .travis.yml. This pull request also test  jdk_switcher. 

Issue #2271 

## Testing

Note: This is testing only. Please do not merge. Thanks.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [x] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [x] Checkstyle
