### PR TITLE
Do not override hasOwnProperty JS builtin, fixing list-widgets

### DIFF
--- a/intermine/webapp/src/main/webapp/convertBag.jsp
+++ b/intermine/webapp/src/main/webapp/convertBag.jsp
@@ -38,10 +38,6 @@
     <input type="text" name="convertToThing" value="Convert" style="display:none;" />
 
     <script type="text/javascript" charset="utf-8">
-        Object.prototype.hasOwnProperty = function(property) {
-            return typeof(this[property]) !== 'undefined'
-        };
-
         function convertBagCallBag(datei) {
           var _i, _len, _ref, _target, _ref1, _ref2;
           _json = jQuery.parseJSON(datei);
@@ -50,7 +46,7 @@
           _ref2 = "count";
           for (_i = 0, _len = _json.length; _i < _len; _i++) {
             _entry = _json[_i];
-            if (_entry.hasOwnProperty(_ref1) && _entry.hasOwnProperty(_ref2)) {
+            if (typeof(_entry[_ref1]) !== 'undefined' && typeof(_entry[_ref2]) !== 'undefined') {
               var _text, _count;
               _name = _entry[_ref1];
               _count = _entry[_ref2];


### PR DESCRIPTION
## Details

Fixes #2282.

Google Charts recently deprecated https://www.google.com/jsapi and replaced it with https://www.gstatic.com/charts/loader.js via a 301 redirect. The new charts loader is actually backwards compatible, (I have tested this fix with both list-widgets 2.1.4 and 2.1.5, which are before and after adopting the [new API](https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code)) but a nefarious piece of near decade old code breaks a JS language feature which the new charts loader happens to rely on.

I only moved the `hasOwnProperty` function definition to be inline where it's used, but since it used to globally override the built-in, it *could* break other JS code which relies on this incorrect implementation of `hasOwnProperty` further down in the HTML document (albeit very unlikely).

## Testing

I have tested locally that the `hasOwnProperty` override is what breaks the list-widgets.
I hope someone familiar with deploying InterMine can test the following with this fix applied:
- The custom converter on the list page (which this snippet seems to get the counts for) is still working like it should
- The list-widgets works again in a complete Flymine/Humanmine deployment

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
