### PR TITLE
Removed gretty plugin from testmine

### DIFF
--- a/testmine/setup.sh
+++ b/testmine/setup.sh
@@ -112,6 +112,6 @@ echo "------> Loading userprofile..."
 ./gradlew insertUserData --stacktrace --no-daemon
 
 echo "------> Running webapp"
-echo "------> Running ./gradlew tomcatstartwar"
-./gradlew tomcatstartwar --no-daemon &
+echo "------> Running ./gradlew cargoRunLocal"
+./gradlew cargoRunLocal --no-daemon &
 echo "------> Finished"

--- a/testmine/webapp/build.gradle
+++ b/testmine/webapp/build.gradle
@@ -1,5 +1,15 @@
 apply plugin: "war"
-apply from: "https://raw.githubusercontent.com/intermine/gretty/master/pluginScripts/gretty.plugin"
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.bmuschko:gradle-cargo-plugin:2.7.1'
+    }
+}
+apply plugin: "com.bmuschko.cargo"
 
 def explodedWebAppDir = "$buildDir/explodedWebApp"
 def mergePropsDir = "$buildDir/props"
@@ -13,6 +23,7 @@ ext {
 
 configurations {
     imWebApp
+    tomcat
 }
 
 dependencies { 
@@ -33,6 +44,7 @@ dependencies {
     runtime group: 'commons-httpclient', name: 'commons-httpclient', version: '3.0'
     runtime group: 'commons-fileupload', name: 'commons-fileupload', version: '1.2.2' 
     imWebApp group: "org.intermine", name: "intermine-webapp", version: imVersion, transitive: false
+    tomcat "org.apache.tomcat:tomcat:8.5.31@zip"
 }
 
 processResources {
@@ -98,15 +110,27 @@ task warTestModelWebApp(type: War) {
     webInf { from "${mergePropsDir}" }
 }
 
-gretty {
-    // needed for Tomcat 8.0.x, Maybe remove for Tomcat 9? Still needed for Tomcat 8.5.x?
-    jvmArgs = ['-Dorg.apache.el.parser.SKIP_IDENTIFIER_CHECK=true']
+cargo {
+    // change this to match your Tomcat major version (keep the x)
+    containerId = 'tomcat8x'
 
-    // read in intermine.properties to get the contextPath
     def props = new Properties()
     file(minePropertyFile).withInputStream { props.load(it) }
 
-    // needed to deploy the webapp
-    contextPath = props.getProperty("webapp.path")
+    // change this to the Tomcat root of your choice
+    deployable {
+        context = props.getProperty("webapp.path")
+    }
+
+    local {
+        installer {
+            installConfiguration = configurations.tomcat
+            downloadDir= file("$buildDir/downloads")
+            extractDir = file("$buildDir/extracts")
+        }
+        jvmArgs = '-Dorg.apache.el.parser.SKIP_IDENTIFIER_CHECK=true'
+    }
 }
+
+cargoRunLocal.dependsOn war
 

--- a/testmine/webapp/build.gradle
+++ b/testmine/webapp/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     runtime group: 'commons-httpclient', name: 'commons-httpclient', version: '3.0'
     runtime group: 'commons-fileupload', name: 'commons-fileupload', version: '1.2.2' 
     imWebApp group: "org.intermine", name: "intermine-webapp", version: imVersion, transitive: false
+    providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
     tomcat "org.apache.tomcat:tomcat:8.5.31@zip"
 }
 


### PR DESCRIPTION
## Details
removed gretty from testmine because the task tomcatStartWar doesn't work with gradle 4.9.
gretty has been replaced with the plugin cargo.
instead of using tomcatStartWar task, we use cargoRunLocal.
travis is ok, and I was able to run testmine locally using cargoRunLocal

## Testing

*Besides running unit tests, how can the reviewer test your feature / bug fix? Are there edge cases to be aware of?*

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
