### PR TITLE
Fix format=jsonobjects queries for simple root classes

### DIFF
--- a/intermine/api/src/main/java/org/intermine/api/results/ResultElement.java
+++ b/intermine/api/src/main/java/org/intermine/api/results/ResultElement.java
@@ -11,6 +11,7 @@ package org.intermine.api.results;
  */
 
 import java.io.Serializable;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.intermine.model.FastPathObject;
 import org.intermine.model.InterMineObject;
@@ -34,6 +35,9 @@ public class ResultElement implements Serializable, ResultCell
     protected final boolean keyField;
     private final Path path;
     private String linkRedirect;
+
+    // this mimics an id for simple objects which do not have an id to make jsonobjects queries work
+    private Integer simpleCellId = null;
 
     /**
      * Constructs a new ResultCell object
@@ -106,13 +110,34 @@ public class ResultElement implements Serializable, ResultCell
     /**
      * Get the Id.
      *
-     * @return the id
+     * @return the id, which may be a simpleCellId if set, or null
      */
     public Integer getId() {
         if (imObj instanceof InterMineObject) {
             return ((InterMineObject) imObj).getId();
+        } else {
+            return simpleCellId;
         }
-        return null;
+    }
+
+    /**
+     * Set a hopefully unique persistent local id for simple objects.
+     * This allows jsonobjects queries to work on queries with simple objects.
+     * Does nothing if simpleCellId has already been set.
+     */
+    public void setSimpleCellId() {
+        if (simpleCellId == null) {
+            // get a 4-digit long from the current time (changes every millisecond)
+            long systime = System.currentTimeMillis();
+            String syssix = String.valueOf(systime - (systime / 10000) * 10000);
+            // tack on a random number between 0 and 99 for good measure
+            String rando = String.valueOf(ThreadLocalRandom.current().nextInt(0, 100));
+            if (rando.length() < 2) {
+                rando = "0" + rando;
+            }
+            int composite = Integer.parseInt(syssix + rando);
+            simpleCellId = new Integer(composite);
+        }
     }
 
     /**

--- a/intermine/webapp/src/main/java/org/intermine/webservice/server/output/JSONResultsIterator.java
+++ b/intermine/webapp/src/main/java/org/intermine/webservice/server/output/JSONResultsIterator.java
@@ -87,6 +87,13 @@ public class JSONResultsIterator implements Iterator<JSONObject>
         }
         while (subIter.hasNext()) {
             List<ResultElement> result = subIter.next();
+            // HACK: create a fake id for simple objects which don't have them
+            for (ResultElement cell : result) {
+                if (cell != null && cell.getId() == null) {
+                    cell.setSimpleCellId();
+                }
+            }
+
             Integer currentId = result.get(0).getId(); // id is guarantor of
                                                        // object identity
             if (lastId != null && !lastId.equals(currentId)) {
@@ -102,8 +109,7 @@ public class JSONResultsIterator implements Iterator<JSONObject>
         return nextObj;
     }
 
-    private void addRowToJsonMap(List<ResultElement> results,
-            Map<String, Object> jsonMap) {
+    private void addRowToJsonMap(List<ResultElement> results, Map<String, Object> jsonMap) {
         setOrCheckClassAndId(results.get(0), viewPaths.get(0), jsonMap);
 
         for (int i = 0; i < results.size(); i++) {
@@ -227,13 +233,14 @@ public class JSONResultsIterator implements Iterator<JSONObject>
             Object mapId = jsonMap.get(ID_KEY);
             if (cellId != null && mapId != null && !jsonMap.get(ID_KEY).equals(cell.getId())) {
                 throw new JSONFormattingException(
-                    "This result element (" + cell + ") does not belong on this map (" + jsonMap
-                    + ") - objectIds don't match (" + jsonMap.get(ID_KEY) + " != " + cell.getId()
-                    + ")");
+                                                  "This result element (" + cell
+                                                  + ") does not belong on this map (" + jsonMap
+                                                  + ") - objectIds don't match ("
+                                                  + jsonMap.get(ID_KEY) + " != " + cell.getId()
+                                                  + ")");
             }
         } else {
-            // If these are simple objects, then just cross our fingers and pray...
-            // TODO: fix this abomination, and actually handle simple objects properly.
+            // If these are simple objects, a fake ID should have been appended.
             jsonMap.put(ID_KEY, cell.getId());
         }
     }
@@ -327,7 +334,6 @@ public class JSONResultsIterator implements Iterator<JSONObject>
                         "Bad path type: " + section.toString());
             }
         }
-
     }
 
     /**

--- a/intermine/webapp/src/main/java/org/intermine/webservice/server/query/result/PathQueryBuilderForJSONObj.java
+++ b/intermine/webapp/src/main/java/org/intermine/webservice/server/query/result/PathQueryBuilderForJSONObj.java
@@ -16,6 +16,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import org.intermine.api.profile.InterMineBag;
 import org.intermine.pathquery.Path;
@@ -84,7 +86,21 @@ public class PathQueryBuilderForJSONObj extends PathQueryBuilder
         List<String> newViews = getAlteredViews(beforeChanges);
         afterChanges.addOrderBy(new OrderElement(newViews.get(0), OrderDirection.ASC));
         afterChanges.addViews(newViews);
-
+        try {
+            // this will throw a PathException if the root class does not have an id
+            String rootClass = afterChanges.getRootClass();
+        } catch (PathException e) {
+            // HACK: remove the inserted id from the view if it's on a simple class
+            Pattern pattern = Pattern.compile("Path\\s(.*?)\\sin\\sview\\slist");
+            Matcher matcher = pattern.matcher(e.toString());
+            while (matcher.find()) {
+                String badPath = matcher.group(1);
+                afterChanges.removeView(badPath);
+                afterChanges.removeOrderBy(badPath);
+            }
+            // restore original order by
+            afterChanges.addOrderBys(beforeChanges.getOrderBy());
+        }
         return afterChanges;
     }
 


### PR DESCRIPTION
## Details

This fixes https://github.com/intermine/intermine/issues/2302 . Instead of having a null value for the id of a simple object which is the root of a PathQuery, which breaks a format=jsonobjects query, a "fake" id is created by ResultElement.setSimpleCellId() for the given cell, and this method is called in JSONResultsIterator if necessary. It is only called there, and only if the root class lacks an id, so "normal" queries are unchanged. The id is dropped from the rebuilt query in PathQueryBuilderForJSONObj and the original order-by is restored.

## Testing

I have tested this against a query on my ExpressionValue, which is a simple object, as well as against "normal" queries on root classes such as Gene or SequenceFeature. I've attached an HTML which demonstrates that the jsonobjects format works.
[query-test.html.gz](https://github.com/danielabutano/intermine/files/5592997/query-test.html.gz)

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [x] Passing unit test for new or updated code (if applicable)
- [x] Passes all tests – according to Travis
- [x] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [x] Checkstyle
