### PR TITLE
Remove invalid draw options, fixing geneExpressionAtlas displayers

### DIFF
--- a/bio/webapp/src/main/webapp/model/geneExpressionAtlasDiseasesDisplayer.jsp
+++ b/bio/webapp/src/main/webapp/model/geneExpressionAtlasDiseasesDisplayer.jsp
@@ -336,13 +336,10 @@
           width:			windowSize()/2.2,
           height:			(9 * n) + 50,
           chartArea:		{left: windowSize()/4, top: 0, height: 9 * n},
-          backgroundColor: 	["0", "CCCCCC", "0.2", "FFFFFF", "0.2"],
           colors: 			['#C9C9FF', '#0000FF', '#59BB14', '#B5E196'],
           fontName: 		"Lucida Grande,Verdana,Geneva,Lucida,Helvetica,Arial,sans-serif",
           fontSize: 		11,
           vAxis: 			{title: 'Condition', titleTextStyle: {color: '#1F7492'}},
-          hAxis:			'none',
-          legend: 			'none',
           hAxis:			{minValue: geneExpressionAtlasDiseasesDisplayer.peaks.down - 2, maxValue: geneExpressionAtlasDiseasesDisplayer.peaks.up + 2}
         };
 

--- a/bio/webapp/src/main/webapp/model/geneExpressionAtlasTissuesDisplayer.jsp
+++ b/bio/webapp/src/main/webapp/model/geneExpressionAtlasTissuesDisplayer.jsp
@@ -336,13 +336,10 @@
           width:			windowSize()/2.2,
           height:			(9 * n) + 50,
           chartArea:		{left: windowSize()/4, top: 0, height: 9 * n},
-          backgroundColor: 	["0", "CCCCCC", "0.2", "FFFFFF", "0.2"],
           colors: 			['#C9C9FF', '#0000FF', '#59BB14', '#B5E196'],
           fontName: 		"Lucida Grande,Verdana,Geneva,Lucida,Helvetica,Arial,sans-serif",
           fontSize: 		11,
           vAxis: 			{title: 'Tissue', titleTextStyle: {color: '#1F7492'}},
-          hAxis:			'none',
-          legend: 			'none',
           hAxis:			{minValue: geneExpressionAtlasTissuesDisplayer.peaks.down - 2, maxValue: geneExpressionAtlasTissuesDisplayer.peaks.up + 2}
         };
 


### PR DESCRIPTION
## Details

A fix for the broken humanmine expression viewers on the gene report page mentioned here: #2282
#2283 only fixed the flymine list widgets; this PR fixes the separate problem causing the humanmine displayers to fail.

It's really only backgroundColor that causes the error, but hAxis and legend are also invalid and don't seem to have an effect (according to https://developers.google.com/chart/interactive/docs/gallery/barchart).

I didn't look into reimplementing the background color with its correct property as the displayer seems to look fine as it is.

## Testing

I only tested this fix with each displayer isolated. You'll need to update the jsp files in a humanmine to test properly.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
