### PR TITLE
Remove setting scoreType in GFF3Converter.java

### DIFF
--- a/bio/core/src/main/java/org/intermine/bio/dataconversion/GFF3Converter.java
+++ b/bio/core/src/main/java/org/intermine/bio/dataconversion/GFF3Converter.java
@@ -384,9 +384,6 @@ public class GFF3Converter extends DataConverter
         Double score = record.getScore();
         if (score != null && !"".equals(String.valueOf(score))) {
             feature.setAttribute("score", String.valueOf(score));
-            if (record.getSource() != null) {
-                feature.setAttribute("scoreType", record.getSource());
-            }
         }
 
         for (Item synonym : synonymsToAdd) {

--- a/bio/core/src/test/java/org/intermine/bio/dataconversion/GFF3ConverterTest.java
+++ b/bio/core/src/test/java/org/intermine/bio/dataconversion/GFF3ConverterTest.java
@@ -120,7 +120,6 @@ public class GFF3ConverterTest extends ItemsTestCase {
 //            10116.attributes.ID=primaryIdentifier
 //            10116.gene.attributes.ID=secondaryIdentifier
 //            10116.attributes.Note=description
-//            10116.mRNA.attributes.Type=scoreType
 //            10116.attributes.Dbxref.EntrezGene=ncbiGeneNumber
 //            10116.attributes.Dbxref.EnsemblGenes=synonym
 //        */

--- a/bio/core/src/test/resources/GFF3ConverterTest.xml
+++ b/bio/core/src/test/resources/GFF3ConverterTest.xml
@@ -18,7 +18,6 @@
 <attribute name="length" value="57592452"/>
 <attribute name="primaryIdentifier" value="Mousechain:14:6:3063417..48830107"/>
 <attribute name="score" value="3.78348525E8"/>
-<attribute name="scoreType" value="mouseChain"/>
 <reference name="chromosome" ref_id="4_2"/>
 <reference name="chromosomeLocation" ref_id="7_2"/>
 <reference name="organism" ref_id="0_1"/>
@@ -56,7 +55,6 @@
 <attribute name="length" value="80"/>
 <attribute name="primaryIdentifier" value="Mousechain:4162060:13:91454738..91454814"/>
 <attribute name="score" value="3301.0"/>
-<attribute name="scoreType" value="mouseChain"/>
 <reference name="chromosome" ref_id="4_2"/>
 <reference name="chromosomeLocation" ref_id="7_3"/>
 <reference name="organism" ref_id="0_1"/>
@@ -71,7 +69,6 @@
 <attribute name="length" value="570"/>
 <attribute name="primaryIdentifier" value="transcript(90+)"/>
 <attribute name="score" value="1000.0"/>
-<attribute name="scoreType" value="firstEF"/>
 <reference name="chromosome" ref_id="4_1"/>
 <reference name="chromosomeLocation" ref_id="7_5"/>
 <reference name="organism" ref_id="0_1"/>
@@ -106,7 +103,6 @@
 <attribute name="length" value="570"/>
 <attribute name="primaryIdentifier" value="transcript(2179-)"/>
 <attribute name="score" value="1000.0"/>
-<attribute name="scoreType" value="firstEF"/>
 <reference name="chromosome" ref_id="4_3"/>
 <reference name="chromosomeLocation" ref_id="7_6"/>
 <reference name="organism" ref_id="0_1"/>
@@ -144,7 +140,6 @@
 <attribute name="length" value="54"/>
 <attribute name="primaryIdentifier" value="Mousechain:4246045:10:58864978..58865031"/>
 <attribute name="score" value="3200.0"/>
-<attribute name="scoreType" value="mouseChain"/>
 <reference name="chromosome" ref_id="4_2"/>
 <reference name="chromosomeLocation" ref_id="7_4"/>
 <reference name="organism" ref_id="0_1"/>

--- a/bio/core/src/test/resources/GFF3ConverterTestDiscontinuous.xml
+++ b/bio/core/src/test/resources/GFF3ConverterTestDiscontinuous.xml
@@ -30,7 +30,6 @@
 <attribute name="length" value="570"/>
 <attribute name="primaryIdentifier" value="transcript(2179-)"/>
 <attribute name="score" value="1000.0"/>
-<attribute name="scoreType" value="firstEF"/>
 <reference name="chromosome" ref_id="4_1"/>
 <reference name="chromosomeLocation" ref_id="7_1"/>
 <reference name="organism" ref_id="0_1"/>

--- a/bio/core/src/test/resources/GFF3ConverterTestRGD.xml
+++ b/bio/core/src/test/resources/GFF3ConverterTestRGD.xml
@@ -32,7 +32,6 @@
 <item id="9_1" class="MRNA">
 <attribute name="length" value="3999273"/>
 <attribute name="primaryIdentifier" value="mRNARGD2752358_t00"/>
-<attribute name="scoreType" value="AAA"/>
 <attribute name="symbol" value="NM_017057"/>
 <reference name="chromosome" ref_id="4_1"/>
 <reference name="chromosomeLocation" ref_id="7_2"/>

--- a/bio/core/src/test/resources/GFF3ConverterTestUnLocated.xml
+++ b/bio/core/src/test/resources/GFF3ConverterTestUnLocated.xml
@@ -11,7 +11,6 @@
 <item id="7_2" class="BindingSite">
 <attribute name="primaryIdentifier" value="Mousechain:4162060:13:91454738..91454814"/>
 <attribute name="score" value="3301.0"/>
-<attribute name="scoreType" value="mouseChain"/>
 <reference name="organism" ref_id="0_1"/>
 <reference name="sequenceOntologyTerm" ref_id="5_3"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
@@ -24,7 +23,6 @@
 <item id="8_1" class="Transcript">
 <attribute name="primaryIdentifier" value="transcript(90+)"/>
 <attribute name="score" value="1000.0"/>
-<attribute name="scoreType" value="firstEF"/>
 <reference name="organism" ref_id="0_1"/>
 <reference name="sequenceOntologyTerm" ref_id="5_4"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
@@ -38,7 +36,6 @@
 <item id="7_3" class="BindingSite">
 <attribute name="primaryIdentifier" value="Mousechain:4246045:10:58864978..58865031"/>
 <attribute name="score" value="3200.0"/>
-<attribute name="scoreType" value="mouseChain"/>
 <reference name="organism" ref_id="0_1"/>
 <reference name="sequenceOntologyTerm" ref_id="5_3"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
@@ -51,7 +48,6 @@
 <item id="7_1" class="BindingSite">
 <attribute name="primaryIdentifier" value="Mousechain:14:6:3063417..48830107"/>
 <attribute name="score" value="3.78348525E8"/>
-<attribute name="scoreType" value="mouseChain"/>
 <reference name="organism" ref_id="0_1"/>
 <reference name="sequenceOntologyTerm" ref_id="5_3"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
@@ -82,7 +78,6 @@
 <item id="8_2" class="Transcript">
 <attribute name="primaryIdentifier" value="transcript(2179-)"/>
 <attribute name="score" value="1000.0"/>
-<attribute name="scoreType" value="firstEF"/>
 <reference name="organism" ref_id="0_1"/>
 <reference name="sequenceOntologyTerm" ref_id="5_4"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>


### PR DESCRIPTION
Removed setAttribute("scoreType", record.getSource()) since it's fundamentally wrong. The score type is not given in a GFF3. The source is not the score type.

## Details

*Summary of pull request, including references to relevant tickets (if applicable).*

## Testing

*Besides running unit tests, how can the reviewer test your feature / bug fix? Are there edge cases to be aware of?*

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [x] Passing unit test for new or updated code (if applicable)
- [x] Passes all tests – according to Travis
- [x] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [x] Checkstyle
