### PR TITLE
Log4j fix round 3

### DIFF
--- a/bio/sources/build.gradle
+++ b/bio/sources/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     }
     
     dependencies {
-        compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.0'
+        compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'
         compile group: 'org.intermine', name: 'bio-core', version: System.getProperty("bioVersion"), transitive: false
         compile group : "org.intermine", name: "intermine-resources", version: System.getProperty("imVersion") // log4j
         compile group: 'commons-collections', name: 'commons-collections', version: '3.2'

--- a/intermine/build.gradle
+++ b/intermine/build.gradle
@@ -22,7 +22,7 @@ subprojects {
     configurations {
         all {
             resolutionStrategy {
-                force 'org.apache.logging.log4j:log4j-1.2-api:2.17.0'
+                force 'org.apache.logging.log4j:log4j-1.2-api:2.17.1'
             }
         }
     }
@@ -30,8 +30,8 @@ subprojects {
     if (it.name != 'intermine-resources') {
         dependencies {
             compile group: 'ant', name: 'ant', version: '1.6.5'
-            compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.0'
-            compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.0'
+            compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'
+            compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.1'
             testCompile group: 'junit', name: 'junit', version: '4.8.2'
         }
 

--- a/testmine/build.gradle
+++ b/testmine/build.gradle
@@ -28,7 +28,7 @@ subprojects {
 
     dependencies {
         compile group: 'ant', name: 'ant', version: '1.6.5'
-        compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.0'
+        compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'
         commonResources group: "org.intermine", name: "intermine-resources", version: imVersion
     }
 


### PR DESCRIPTION
## Details

This pull request fixes CVE-2021-44832 (also RCE bug). Log4j 2.17.0 is upgraded to 2.17.1. I am not sure if InterMine is exploitable using these Log4j bugs, but we should fix this for compliance, department security policy etc. 

## Testing

Works on GitHub actions

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [x] Passing unit test for new or updated code (if applicable)
- [x] Passes all tests – according to Travis
- [x] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [x] Checkstyle
