### PR TITLE
Fix Strain definition, had mixup with LIS genomic_additions.

### DIFF
--- a/bio/model/core.xml
+++ b/bio/model/core.xml
@@ -191,10 +191,11 @@
         <collection name="childFeatures" referenced-type="SequenceFeature" />
     </class>
 
-    <class name="Strain" extends="BioEntity" is-interface="true">
-        <attribute name="annotationVersion" type="java.lang.String"/>
-        <attribute name="assemblyVersion" type="java.lang.String"/>
-        <collection name="features" referenced-type="SequenceFeature" reverse-reference="strain" />
+    <class name="Strain" is-interface="true" term="http://semanticscience.org/resource/SIO_010055">
+      <attribute name="identifier" type="java.lang.String" term="http://edamontology.org/data_2379"/>
+      <attribute name="name" type="java.lang.String" term="http://edamontology.org/data_1046"/>
+      <attribute name="accession" type="java.lang.String" term="http://edamontology.org/data_2912"/>
+      <reference name="organism" referenced-type="Organism" reverse-reference="strains"/>
     </class>
 
     <class name="Synonym" is-interface="true" term="http://semanticscience.org/resource/SIO_000122">


### PR DESCRIPTION
## Details

Just saw that I'd swapped my core Strain definition and LIS extensions between core.xml and genomic_additions.xml so that the PR I did for core.xml had the wrong stuff. This fixes that. Strain is a lot like Organism, with attributes
```
<attribute name="identifier" type="java.lang.String" term="http://edamontology.org/data_2379"/>                                                                                        
<attribute name="name" type="java.lang.String" term="http://edamontology.org/data_1046"/>                                                                                              
<attribute name="accession" type="java.lang.String" term="http://edamontology.org/data_2912"/>                                                                                         
```
along with the organism reference. The identifier is meant to be unique within a mine, e.g. "CB5-2"; the name is a more common name for the strain ("California Blackeye"); the accession is typically a genbank accession ("PI 583259"). Those are plant examples but I think it's a general specification of a "strain".

## Testing

I think the LIS mines are the only ones using Strain to date. This change shouldn't have any affect on anyone, including LIS since I just swapped what's in core.xml and in genomic_additions.xml.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [ ] Single purpose
- [ ] Detailed commit messages
- [ ] Well commented code
- [ ] Checkstyle
