### PR TITLE
Strain update to remove as BioEntity, add a couple attributes.

### DIFF
--- a/bio/model/core.xml
+++ b/bio/model/core.xml
@@ -18,6 +18,7 @@
         <attribute name="symbol" type="java.lang.String" term="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <attribute name="name" type="java.lang.String" term="http://www.w3.org/2000/01/rdf-schema#label"/>
         <reference name="organism" referenced-type="Organism" term="http://purl.org/net/orth#organism"/>
+        <reference name="strain" referenced-type="Strain" term="http://semanticscience.org/resource/SIO_010055"/>
         <collection name="locatedFeatures" referenced-type="Location" reverse-reference="locatedOn"/>
         <collection name="locations" referenced-type="Location" reverse-reference="feature" />
         <collection name="synonyms" referenced-type="Synonym" reverse-reference="subject" term="http://purl.obolibrary.org/obo/synonym"/>
@@ -137,7 +138,7 @@
         <attribute name="commonName" type="java.lang.String" term="http://edamontology.org/data_2909"/>
         <attribute name="shortName" type="java.lang.String" term="http://edamontology.org/data_2909"/>
         <attribute name="name" type="java.lang.String" term="http://www.w3.org/2000/01/rdf-schema#label"/>
-        <collection name="strains" referenced-type="Strain"/>
+        <collection name="strains" referenced-type="Strain" reverse-reference="organism"/>
     </class>
 
     <class name="Protein" extends="BioEntity" is-interface="true" term="http://purl.uniprot.org/core/Protein,http://semanticscience.org/resource/SIO_010043">
@@ -186,15 +187,19 @@
         <reference name="chromosome" referenced-type="Chromosome" term="http://purl.org/dc/terms/isPartOf"/>
         <reference name="chromosomeLocation" referenced-type="Location" />
         <reference name="sequenceOntologyTerm" referenced-type="SOTerm"/>
-        <reference name="strain" referenced-type="Strain"  reverse-reference="features" />
+        <reference name="strain" referenced-type="Strain" />
         <collection name="overlappingFeatures" referenced-type="SequenceFeature" />
         <collection name="childFeatures" referenced-type="SequenceFeature" />
     </class>
 
-    <class name="Strain" extends="BioEntity" is-interface="true" term="http://semanticscience.org/resource/SIO_010055">
-        <attribute name="annotationVersion" type="java.lang.String"/>
-        <attribute name="assemblyVersion" type="java.lang.String"/>
-        <collection name="features" referenced-type="SequenceFeature" reverse-reference="strain" />
+    <class name="Strain" is-interface="true" term="http://semanticscience.org/resource/SIO_010055">
+      <attribute name="identifier" type="java.lang.String" term="http://edamontology.org/data_2379"/>
+      <attribute name="description" type="java.lang.String"/>
+      <attribute name="name" type="java.lang.String" term="http://edamontology.org/data_1046"/>
+      <attribute name="origin" type="java.lang.String"/>
+      <attribute name="accession" type="java.lang.String" term="http://edamontology.org/data_2912"/>
+      <reference name="organism" referenced-type="Organism" reverse-reference="strains" term="http://purl.org/net/orth#organism"/>
+      <collection name="dataSets" referenced-type="DataSet"/>
     </class>
 
     <class name="Synonym" is-interface="true" term="http://semanticscience.org/resource/SIO_000122">


### PR DESCRIPTION
## Details

This is a correction of Strain definition which should NOT be a BioEntity. It is simply an Organism sub-type and is not a genomic feature. In addition to the usual attributes _identifier_, _description_, and _name_ I've included a couple extra that we use at LIS for plants but I think are generally applicable (e.g. to mice): _origin_ and _accession_. If you don't want those, I can yank them.

This adds the _strain_ reference to BioEntity, of course, since if you're using Strain your stuff is associated with one. (LIS strains are plant cultivars and landraces.)

## Testing

I don't think Strain is in use yet outside of LIS, so this update should have minimal impact. At LIS we've been using this model for quite a while, 5.1.0.1 got a really old Strain definition.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [ ] Checkstyle
