### PR TITLE
Fixes the problem with simple objects in jsonobjects queries.

### DIFF
--- a/intermine/api/src/main/java/org/intermine/api/results/ResultElement.java
+++ b/intermine/api/src/main/java/org/intermine/api/results/ResultElement.java
@@ -126,10 +126,8 @@ public class ResultElement implements Serializable, ResultCell
      * Does nothing if simpleCellId has already been set.
      */
     public void setSimpleCellId() {
-        if (simpleCellId == null) {
-            // get a random number between 90000000 and 99999999
-            simpleCellId = new Integer(ThreadLocalRandom.current().nextInt(90000000, 100000000));
-        }
+        // set to a random number between 90000000 and 99999999
+        simpleCellId = new Integer(ThreadLocalRandom.current().nextInt(90000000, 100000000));
     }
 
     /**

--- a/intermine/api/src/main/java/org/intermine/api/results/ResultElement.java
+++ b/intermine/api/src/main/java/org/intermine/api/results/ResultElement.java
@@ -126,8 +126,10 @@ public class ResultElement implements Serializable, ResultCell
      * Does nothing if simpleCellId has already been set.
      */
     public void setSimpleCellId() {
-        // set to a random number between 90000000 and 99999999
-        simpleCellId = new Integer(ThreadLocalRandom.current().nextInt(90000000, 100000000));
+        if (simpleCellId==null) {
+            // set to a random number between 90000000 and 99999999
+            simpleCellId = new Integer(ThreadLocalRandom.current().nextInt(90000000, 100000000));
+        }
     }
 
     /**

--- a/intermine/api/src/main/java/org/intermine/api/results/ResultElement.java
+++ b/intermine/api/src/main/java/org/intermine/api/results/ResultElement.java
@@ -127,16 +127,8 @@ public class ResultElement implements Serializable, ResultCell
      */
     public void setSimpleCellId() {
         if (simpleCellId == null) {
-            // get a 4-digit long from the current time (changes every millisecond)
-            long systime = System.currentTimeMillis();
-            String syssix = String.valueOf(systime - (systime / 10000) * 10000);
-            // tack on a random number between 0 and 99 for good measure
-            String rando = String.valueOf(ThreadLocalRandom.current().nextInt(0, 100));
-            if (rando.length() < 2) {
-                rando = "0" + rando;
-            }
-            int composite = Integer.parseInt(syssix + rando);
-            simpleCellId = new Integer(composite);
+            // get a random number between 90000000 and 99999999
+            simpleCellId = new Integer(ThreadLocalRandom.current().nextInt(90000000, 100000000));
         }
     }
 

--- a/intermine/webapp/src/main/java/org/intermine/webservice/server/output/JSONResultsIterator.java
+++ b/intermine/webapp/src/main/java/org/intermine/webservice/server/output/JSONResultsIterator.java
@@ -49,6 +49,8 @@ public class JSONResultsIterator implements Iterator<JSONObject>
     protected transient List<Map<String, Object>> currentArray;
     private Model model;
 
+    private List<Integer> idList;
+
     /**
      * Constructor. The JSON Iterator sits on top of the basic export results iterator.
      * @param it An ExportResultsIterator
@@ -61,6 +63,7 @@ public class JSONResultsIterator implements Iterator<JSONObject>
     private void init() {
         model = subIter.getQuery().getModel();
         viewPaths.addAll(subIter.getViewPaths());
+        idList = new ArrayList<>();
     }
 
     /**
@@ -87,10 +90,14 @@ public class JSONResultsIterator implements Iterator<JSONObject>
         }
         while (subIter.hasNext()) {
             List<ResultElement> result = subIter.next();
-            // HACK: create a fake id for simple objects which don't have them
+            // HACK: create a fake id for any simple objects in the result
+            // use while loop with idList to avoid duplicates
             for (ResultElement cell : result) {
                 if (cell != null && cell.getId() == null) {
-                    cell.setSimpleCellId();
+                    while (cell.getId() == null || idList.contains(cell.getId())) {
+                        cell.setSimpleCellId();
+                    }
+                    idList.add(cell.getId());
                 }
             }
 


### PR DESCRIPTION
## Details

This is an update to the routine that creates unique IDs for simple objects in the front of path queries for _jsonobjects_ output. The previous code led to non-unique IDs which caused the query output to break. This code generates a random ID between 90000000 and 99999999 but also uses a List and while loop to ensure that the generated ID is unique. So, a pretty minor change but needed for queries on simple objects.

## Testing

This fix has been robust (so far) for my testing against ExpressionValue queries in LIS mines. ExpressionValue is a simple object.

## Checklist

Before your pull request can be approved, be sure to check all boxes:

- [ ] Passing unit test for new or updated code (if applicable)
- [ ] Passes all tests – according to Travis
- [ ] Documentation (if applicable)
- [x] Single purpose
- [x] Detailed commit messages
- [x] Well commented code
- [ ] Checkstyle
